### PR TITLE
Custom spider template

### DIFF
--- a/templates/spider.tmpl
+++ b/templates/spider.tmpl
@@ -2,6 +2,7 @@
 import scrapy
 from documenters_aggregator.spider import Spider
 
+
 class {{ classname }}(Spider):
     name = '{{ name }}'
     long_name = '{{ long_name }}'
@@ -18,7 +19,7 @@ class {{ classname }}(Spider):
         """
         for item in response.css('.eventspage'):
 
-        data = {
+            data = {
                 '_type': 'event',
                 'id': self._parse_id(item),
                 'name': self._parse_name(item),

--- a/templates/spider.tmpl
+++ b/templates/spider.tmpl
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import scrapy
+from documenters_aggregator.spider import Spider
 
-
-class {{ classname }}(scrapy.Spider):
+class {{ classname }}(Spider):
     name = '{{ name }}'
     long_name = '{{ long_name }}'
     allowed_domains = [{{ domains|quote_list|join(', ') }}]
@@ -17,7 +17,8 @@ class {{ classname }}(scrapy.Spider):
         needs.
         """
         for item in response.css('.eventspage'):
-            yield {
+
+        data = {
                 '_type': 'event',
                 'id': self._parse_id(item),
                 'name': self._parse_name(item),
@@ -26,10 +27,15 @@ class {{ classname }}(scrapy.Spider):
                 'start_time': self._parse_start(item),
                 'end_time': self._parse_end(item),
                 'timezone': self._parse_timezone(item),
+                'status': 'self._parse_status(item)',
                 'all_day': self._parse_all_day(item),
                 'location': self._parse_location(item),
                 'sources': self._parse_sources(item),
             }
+
+        data['id'] = self._generate_id(data, start_time)
+
+        yield data
 
         # self._parse_next(response) yields more responses to parse if necessary.
         # uncomment to find a "next" url
@@ -110,6 +116,17 @@ class {{ classname }}(scrapy.Spider):
             },
         }
 
+    def _parse_status(self, item):
+        """
+        Parse or generate status of meeting. Can be one of:
+        * cancelled
+        * tentative
+        * confirmed
+        * passed
+        By default, return "tentative"
+        """
+        return 'tentative'
+
     def _parse_sources(self, item):
         """
         Parse or generate sources.
@@ -118,4 +135,3 @@ class {{ classname }}(scrapy.Spider):
             'url': '',
             'note': '',
         }]
-


### PR DESCRIPTION
Inherit from custom `documenters_aggregator` spider. Should resolve #235.  Could possibly use edits in case the template data object returned is still slightly different from the current schema 