### PR TITLE
Auto deploy lambda scheduler

### DIFF
--- a/deploy/aws_setup.py
+++ b/deploy/aws_setup.py
@@ -117,9 +117,13 @@ def get_definitions(family_name):
 
 
 def update_lambda_function():
-    run('zip -X -r code.zip deploy/scraperScheduler/*')
+    with open("deploy/scraperScheduler/spiders.txt", "w") as file:
+        file.write("\n".join(spider_names))
+
+    run('zip -X -j -r code.zip deploy/scraperScheduler/*')
     run('aws lambda update-function-code --function-name scraperScheduler --zip-file fileb://code.zip')
     run('rm code.zip')
+    run('rm deploy/scraperScheduler/spiders.txt')
 
 
 def quote_for_awscli(data):

--- a/deploy/aws_setup.py
+++ b/deploy/aws_setup.py
@@ -115,10 +115,12 @@ def get_definitions(family_name):
     }
     return quote_for_awscli([definition])
 
+
 def update_lambda_function():
     run('zip -X -r code.zip deploy/scraperScheduler/*')
     run('aws lambda update-function-code --function-name scraperScheduler --zip-file fileb://code.zip')
     run('rm code.zip')
+
 
 def quote_for_awscli(data):
     # The following is an ugly but functional way of creating the quoting

--- a/deploy/aws_setup.py
+++ b/deploy/aws_setup.py
@@ -115,6 +115,10 @@ def get_definitions(family_name):
     }
     return quote_for_awscli([definition])
 
+def update_lambda_function():
+    run('zip -X -r code.zip deploy/scraperScheduler/*')
+    run('aws lambda update-function-code --function-name scraperScheduler --zip-file fileb://code.zip')
+    run('rm code.zip')
 
 def quote_for_awscli(data):
     # The following is an ugly but functional way of creating the quoting
@@ -125,3 +129,4 @@ def quote_for_awscli(data):
 
 create_log_groups()
 create_task_definitions()
+update_lambda_function()

--- a/deploy/scraperScheduler/index.js
+++ b/deploy/scraperScheduler/index.js
@@ -1,0 +1,53 @@
+const AWS = require('aws-sdk')
+const ecs = new AWS.ECS();
+
+const tasks = [
+    'chi_animal',
+    'chi_buildings',
+    'chi_city_college',
+    'chi_citycouncil',
+    'chi_infra',
+    'chi_library',
+    'chi_parks',
+    'chi_police',
+    'chi_policeboard',
+    'chi_pubhealth',
+    'chi_school_actions',
+    'chi_schools',
+    'chi_transit',
+    'cook_board',
+    'cook_county',
+    'cook_electoral',
+    'cook_hospitals',
+    'cook_landbank',
+    'cook_pubhealth',
+    'il_labor',
+    'il_pubhealth',
+    'regionaltransit',
+    'ward_night',
+];
+
+exports.handler = (events, context) => {
+    const now = new Date();
+    const hour = now.getHours();
+    const task = tasks[hour];
+
+    if (!task) {
+        console.log(`no task for index ${hour}; we're done here.`)
+        return;
+    }
+
+    const params = {
+        taskDefinition: `documenters_aggregator-${task}`,
+        cluster: 'documenters-aggregator-production',
+        count: 1
+    };
+    ecs.runTask(params, (err, data) => {
+        if (err) {
+            console.log(err, err.stack);
+        } else {
+            console.log(data);
+        }
+        context.done(err, data);
+    });
+};

--- a/deploy/scraperScheduler/index.js
+++ b/deploy/scraperScheduler/index.js
@@ -1,31 +1,14 @@
-const AWS = require('aws-sdk')
+const AWS = require('aws-sdk');
 const ecs = new AWS.ECS();
 
-const tasks = [
-    'chi_animal',
-    'chi_buildings',
-    'chi_city_college',
-    'chi_citycouncil',
-    'chi_infra',
-    'chi_library',
-    'chi_parks',
-    'chi_police',
-    'chi_policeboard',
-    'chi_pubhealth',
-    'chi_school_actions',
-    'chi_schools',
-    'chi_transit',
-    'cook_board',
-    'cook_county',
-    'cook_electoral',
-    'cook_hospitals',
-    'cook_landbank',
-    'cook_pubhealth',
-    'il_labor',
-    'il_pubhealth',
-    'regionaltransit',
-    'ward_night',
-];
+const fs = require('fs');
+const spiders = fs.readFileSync('./spiders.txt', {encoding: 'utf-8'});
+
+const tasks = spiders.trim().split("\n").sort();
+
+if (tasks.length > 48) {
+  throw "Too many tasks defined!";
+}
 
 exports.handler = (events, context) => {
     const now = new Date();


### PR DESCRIPTION
When this is merged, the script that chooses which spider to run will be updated on every deploy.

It is currently setup to run every 30 minutes. When we have more than 48 spiders, we'll need to reassess this to avoid spiders from being skipped.