### PR TITLE
Rebuild PBCC spider for updated site

### DIFF
--- a/tests/files/chi_buildings.html
+++ b/tests/files/chi_buildings.html
@@ -1,1469 +1,381 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-
+<!DOCTYPE html>
+<html lang="en-US" prefix="og: http://ogp.me/ns#">
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<link rel="profile" href="http://gmpg.org/xfn/11">
+	<title>Pre-Bid Meeting - Chicago Park District Group B (C1595) - PBC Chicago</title>
+		<script type="text/javascript">
+		var ajaxurl = 'http://www.pbcchicago.com/wp-admin/admin-ajax.php';
+		</script>
+		
+<!-- This site is optimized with the Yoast SEO plugin v5.8 - https://yoast.com/wordpress/plugins/seo/ -->
+<meta name="robots" content="noindex,follow"/>
+<link rel="canonical" href="http://www.pbcchicago.com/events/event/pre-bid-meeting-chicago-park-district-group-b-c1595/" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Pre-Bid Meeting - Chicago Park District Group B (C1595) - PBC Chicago" />
+<meta property="og:description" content="Event Details Date: February 21, 2018 9:30 am &ndash; 1:00 pm Venue: McKinley Park Auditorium Categories: Opportunity On Wednesday, February 21, 2018, in the McKinley Park Auditorium, located at 2210 West Pershing Road, Chicago, Illinois 60609, PBC will host a Pre-Bid Meeting at 9:30 a.m., a Mandatory Technical Review Meeting at 10:00a.m., and a Non-Mandatory Site Visit at ... Read more" />
+<meta property="og:url" content="http://www.pbcchicago.com/events/event/pre-bid-meeting-chicago-park-district-group-b-c1595/" />
+<meta property="og:site_name" content="PBC Chicago" />
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:description" content="Event Details Date: February 21, 2018 9:30 am &ndash; 1:00 pm Venue: McKinley Park Auditorium Categories: Opportunity On Wednesday, February 21, 2018, in the McKinley Park Auditorium, located at 2210 West Pershing Road, Chicago, Illinois 60609, PBC will host a Pre-Bid Meeting at 9:30 a.m., a Mandatory Technical Review Meeting at 10:00a.m., and a Non-Mandatory Site Visit at ... Read more" />
+<meta name="twitter:title" content="Pre-Bid Meeting - Chicago Park District Group B (C1595) - PBC Chicago" />
+<script type='application/ld+json'>{"@context":"http:\/\/schema.org","@type":"WebSite","@id":"#website","url":"http:\/\/www.pbcchicago.com\/","name":"PBC Chicago","potentialAction":{"@type":"SearchAction","target":"http:\/\/www.pbcchicago.com\/?s={search_term_string}","query-input":"required name=search_term_string"}}</script>
+<!-- / Yoast SEO plugin. -->
 
-	
-
-<title>Public Building Commission of Chicago | PBC Calendar</title>
-
+<link rel='dns-prefetch' href='//platform.twitter.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<link href='https://fonts.gstatic.com' crossorigin rel='preconnect' />
+<link rel="alternate" type="application/rss+xml" title="PBC Chicago &raquo; Feed" href="http://www.pbcchicago.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="PBC Chicago &raquo; Comments Feed" href="http://www.pbcchicago.com/comments/feed/" />
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/72x72\/","ext":".png","svgUrl":"https:\/\/s.w.org\/images\/core\/emoji\/2.3\/svg\/","svgExt":".svg","source":{"concatemoji":"http:\/\/www.pbcchicago.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.8.5"}};
+			!function(a,b,c){function d(a){var b,c,d,e,f=String.fromCharCode;if(!k||!k.fillText)return!1;switch(k.clearRect(0,0,j.width,j.height),k.textBaseline="top",k.font="600 32px Arial",a){case"flag":return k.fillText(f(55356,56826,55356,56819),0,0),b=j.toDataURL(),k.clearRect(0,0,j.width,j.height),k.fillText(f(55356,56826,8203,55356,56819),0,0),c=j.toDataURL(),b!==c&&(k.clearRect(0,0,j.width,j.height),k.fillText(f(55356,57332,56128,56423,56128,56418,56128,56421,56128,56430,56128,56423,56128,56447),0,0),b=j.toDataURL(),k.clearRect(0,0,j.width,j.height),k.fillText(f(55356,57332,8203,56128,56423,8203,56128,56418,8203,56128,56421,8203,56128,56430,8203,56128,56423,8203,56128,56447),0,0),c=j.toDataURL(),b!==c);case"emoji4":return k.fillText(f(55358,56794,8205,9794,65039),0,0),d=j.toDataURL(),k.clearRect(0,0,j.width,j.height),k.fillText(f(55358,56794,8203,9794,65039),0,0),e=j.toDataURL(),d!==e}return!1}function e(a){var c=b.createElement("script");c.src=a,c.defer=c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var f,g,h,i,j=b.createElement("canvas"),k=j.getContext&&j.getContext("2d");for(i=Array("flag","emoji4"),c.supports={everything:!0,everythingExceptFlag:!0},h=0;h<i.length;h++)c.supports[i[h]]=d(i[h]),c.supports.everything=c.supports.everything&&c.supports[i[h]],"flag"!==i[h]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[i[h]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(g=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",g,!1),a.addEventListener("load",g,!1)):(a.attachEvent("onload",g),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),f=c.source||{},f.concatemoji?e(f.concatemoji):f.wpemoji&&f.twemoji&&(e(f.twemoji),e(f.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wgs2-css'  href='http://www.pbcchicago.com/wp-content/plugins/wp-google-search/wgs2.css?ver=4.8.5' type='text/css' media='all' />
+<link rel='stylesheet' id='generate-fonts-css'  href='//fonts.googleapis.com/css?family=Fira+Sans:300,300italic,regular,italic,500,500italic,700,700italic' type='text/css' media='all' />
+<link rel='stylesheet' id='social-icons-widget-widget-css'  href='http://www.pbcchicago.com/wp-content/plugins/social-media-icons-widget/css/social_icons_widget.css?ver=4.8.5' type='text/css' media='all' />
+<link rel='stylesheet' id='ctct_form_styles-css'  href='http://www.pbcchicago.com/wp-content/plugins/constant-contact-forms/assets/css/style.css?ver=1.3.5' type='text/css' media='all' />
+<link rel='stylesheet' id='ctf_styles-css'  href='http://www.pbcchicago.com/wp-content/plugins/custom-twitter-feeds/css/ctf-styles.css?ver=1.2.7' type='text/css' media='all' />
+<link rel='stylesheet' id='rs-plugin-settings-css'  href='http://www.pbcchicago.com/wp-content/plugins/revslider/public/assets/css/settings.css?ver=5.1' type='text/css' media='all' />
+<style id='rs-plugin-settings-inline-css' type='text/css'>
+#rs-demo-id {}
+</style>
+<link rel='stylesheet' id='bb-tcs-editor-style-shared-css'  href='http://www.pbcchicago.com/wp-content/pbcCSSeditor-style-shared.css?ver=4.8.5' type='text/css' media='all' />
+<link rel='stylesheet' id='editor-style-css'  href='http://www.pbcchicago.com/wp-content/themes/generatepress-child/?ver=4.8.5' type='text/css' media='all' />
+<link rel='stylesheet' id='generate-style-grid-css'  href='http://www.pbcchicago.com/wp-content/themes/generatepress/css/unsemantic-grid.min.css?ver=1.3.46' type='text/css' media='all' />
+<link rel='stylesheet' id='generate-style-css'  href='http://www.pbcchicago.com/wp-content/themes/generatepress/style.css?ver=1.3.46' type='text/css' media='all' />
+<style id='generate-style-inline-css' type='text/css'>
+body{background-color:#ffffff;color:#3a3a3a;}a, a:visited{color:#1e73be;text-decoration:none;}a:visited{color:#1e73be;}a:hover, a:focus, a:active{color:#8ba2bd;text-decoration:none;}body .grid-container{max-width:1300px;}
+body, button, input, select, textarea{font-family:"Fira Sans", sans-serif;font-size:14px;}p{margin-bottom:1.4em;}.main-navigation .main-nav ul ul li a{font-size:14px;}@media (max-width:768px){.main-title{font-size:30px;}h1{font-size:30px;}h2{font-size:25px;}}
+.site-header{background-color:#ffffff;color:#3a3a3a;}.site-header a,.site-header a:visited{color:#3a3a3a;}.main-title a,.main-title a:hover,.main-title a:visited{color:#222222;}.site-description{color:#999999;}.main-navigation,.main-navigation ul ul{background-color:#222222;}.main-navigation .main-nav ul li a,.menu-toggle{color:#ffffff;}.main-navigation .main-nav ul li > a:hover,.main-navigation .main-nav ul li > a:focus, .main-navigation .main-nav ul li.sfHover > a{color:#ffffff;background-color:#3f3f3f;}button.menu-toggle:hover,button.menu-toggle:focus,.main-navigation .mobile-bar-items a,.main-navigation .mobile-bar-items a:hover,.main-navigation .mobile-bar-items a:focus{color:#ffffff;}.main-navigation .main-nav ul li[class*="current-menu-"] > a{color:#ffffff;background-color:#3f3f3f;}.main-navigation .main-nav ul li[class*="current-menu-"] > a:hover,.main-navigation .main-nav ul li[class*="current-menu-"].sfHover > a{color:#ffffff;background-color:#3f3f3f;}.main-navigation ul ul{background-color:#3f3f3f;}.main-navigation .main-nav ul ul li a{color:#ffffff;}.main-navigation .main-nav ul ul li > a:hover,.main-navigation .main-nav ul ul li > a:focus,.main-navigation .main-nav ul ul li.sfHover > a{color:#ffffff;background-color:#4f4f4f;}.main-navigation .main-nav ul ul li[class*="current-menu-"] > a{color:#ffffff;background-color:#4f4f4f;}.main-navigation .main-nav ul ul li[class*="current-menu-"] > a:hover,.main-navigation .main-nav ul ul li[class*="current-menu-"].sfHover > a{color:#ffffff;background-color:#4f4f4f;}.separate-containers .inside-article, .separate-containers .comments-area, .separate-containers .page-header, .one-container .container, .separate-containers .paging-navigation, .inside-page-header{background-color:#ffffff;}.entry-meta{color:#888888;}.entry-meta a,.entry-meta a:visited{color:#666666;}.entry-meta a:hover{color:#1e73be;}.footer-widgets{background-color:#ffffff;}.footer-widgets .widget-title{color:#000000;}.site-info{color:#ffffff;background-color:#222222;}.site-info a,.site-info a:visited{color:#ffffff;}.site-info a:hover{color:#606060;}.footer-bar .widget_nav_menu .current-menu-item a{color:#606060;}input[type="text"],input[type="email"],input[type="url"],input[type="password"],input[type="search"],textarea{color:#666666;background-color:#fafafa;border-color:#cccccc;}input[type="text"]:focus,input[type="email"]:focus,input[type="url"]:focus,input[type="password"]:focus,input[type="search"]:focus,textarea:focus{color:#666666;background-color:#ffffff;border-color:#bfbfbf;}button,html input[type="button"],input[type="reset"],input[type="submit"],.button,.button:visited{color:#ffffff;background-color:#666666;}button:hover,html input[type="button"]:hover,input[type="reset"]:hover,input[type="submit"]:hover,.button:hover,button:focus,html input[type="button"]:focus,input[type="reset"]:focus,input[type="submit"]:focus,.button:focus{color:#ffffff;background-color:#3f3f3f;}
+@media (max-width:768px){.separate-containers .inside-article, .separate-containers .comments-area, .separate-containers .page-header, .separate-containers .paging-navigation, .one-container .site-content, .inside-page-header{padding:30px;}}.main-navigation ul ul{top:auto;}
+</style>
+<link rel='stylesheet' id='generate-mobile-style-css'  href='http://www.pbcchicago.com/wp-content/themes/generatepress/css/mobile.min.css?ver=1.3.46' type='text/css' media='all' />
+<link rel='stylesheet' id='generate-child-css'  href='http://www.pbcchicago.com/wp-content/themes/generatepress-child/style.css?ver=1515787510' type='text/css' media='all' />
+<link rel='stylesheet' id='fontawesome-css'  href='http://www.pbcchicago.com/wp-content/themes/generatepress/css/font-awesome.min.css?ver=4.7' type='text/css' media='all' />
+<!--[if lt IE 9]>
+<link rel='stylesheet' id='generate-ie-css'  href='http://www.pbcchicago.com/wp-content/themes/generatepress/css/ie.min.css?ver=1.3.46' type='text/css' media='all' />
+<![endif]-->
+<script type='text/javascript' src='https://platform.twitter.com/widgets.js?ver=4.8.5'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/revslider/public/assets/js/jquery.themepunch.tools.min.js?ver=5.1'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/revslider/public/assets/js/jquery.themepunch.revolution.min.js?ver=5.1'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/revslider/public/assets/css/settings.css?ver=4.8.5'></script>
+<link rel='https://api.w.org/' href='http://www.pbcchicago.com/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://www.pbcchicago.com/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://www.pbcchicago.com/wp-includes/wlwmanifest.xml" /> 
+<meta name="generator" content="WordPress 4.8.5" />
+<link rel='shortlink' href='http://www.pbcchicago.com/?p=88782' />
+<link rel="alternate" type="application/json+oembed" href="http://www.pbcchicago.com/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwww.pbcchicago.com%2Fevents%2Fevent%2Fpre-bid-meeting-chicago-park-district-group-b-c1595%2F" />
+<link rel="alternate" type="text/xml+oembed" href="http://www.pbcchicago.com/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwww.pbcchicago.com%2Fevents%2Fevent%2Fpre-bid-meeting-chicago-park-district-group-b-c1595%2F&#038;format=xml" />
+<!-- <meta name="vfb" version="2.9.4" /> -->
+<meta name="viewport" content="width=device-width, initial-scale=1"><meta name="generator" content="Powered by Visual Composer - drag and drop page builder for WordPress."/>
+<!--[if lte IE 9]><link rel="stylesheet" type="text/css" href="http://www.pbcchicago.com/wp-content/plugins/js_composer/assets/css/vc_lte_ie9.min.css" media="screen"><![endif]--><!--[if IE  8]><link rel="stylesheet" type="text/css" href="http://www.pbcchicago.com/wp-content/plugins/js_composer/assets/css/vc-ie8.min.css" media="screen"><![endif]--><meta name="generator" content="Powered by Slider Revolution 5.1 - responsive, Mobile-Friendly Slider Plugin for WordPress with comfortable drag and drop interface." />
+<!-- BEGIN GADWP v5.1.2.5 Universal Analytics - https://deconf.com/google-analytics-dashboard-wordpress/ -->
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-81730424-1', 'auto');
   ga('send', 'pageview');
-
 </script>
+<!-- END GADWP Universal Analytics -->
+<noscript><style type="text/css"> .wpb_animate_when_almost_visible { opacity: 1; }</style></noscript></head>
 
+<body itemtype='http://schema.org/Blog' itemscope='itemscope' class="event-template-default single single-event postid-88782 single-format-standard wp-custom-logo ctct-generatepress  no-sidebar nav-below-header contained-header separate-containers active-footer-widgets-3 nav-aligned-center header-aligned-left dropdown-hover wpb-js-composer js-comp-ver-4.12.1 vc_responsive">
+	<a class="screen-reader-text skip-link" href="#content" title="Skip to content">Skip to content</a>
+			<header itemtype="http://schema.org/WPHeader" itemscope="itemscope" id="masthead" class="site-header grid-container grid-parent">
+		<div class="inside-header">
+								<div class="header-widget">
+			<aside id="nav_menu-13" class="widget inner-padding widget_nav_menu"><div class="menu-top-nav-container"><ul id="menu-top-nav" class="menu"><li id="menu-item-953" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-953"><a href="http://www.pbcchicago.com/foia/">FOIA</a></li>
+<li id="menu-item-952" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-952"><a href="http://www.pbcchicago.com/calendar/">Calendar</a></li>
+<li id="menu-item-88033" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88033"><a href="http://www.pbcchicago.com/2018-meetings/">Meetings</a></li>
+<li id="menu-item-68" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-68"><a href="http://www.pbcchicago.com/contact/">Contact</a></li>
+</ul></div></aside><aside id="text-5" class="widget inner-padding widget_text">			<div class="textwidget"><div class="socialMedia-icons"><a href="http://www.facebook.com/pages/Public-Building-Commission-of-Chicago/218267174868954" target="_blank"><img src="/wp-content/uploads/SocialMedia/PBC_SocialMediaIcons_Facebook.png" alt="Facebook" style="width:24px;height:24px; padding: 4px"></a>
 
+<a href="http://www.twitter.com/PBCChi" target="_blank"><img src="/wp-content/uploads/SocialMedia/PBC_SocialMediaIcons_Twitter.png" alt="Twitter" style="width:24px;height:24px;padding: 4px"></a>
 
-	<link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon" />
-	
-	<link rel="stylesheet" type="text/css" href="/css/base.css" media="all" />
-	<link rel="stylesheet" type="text/css" href="/css/print.css" media="print" />
-
-	<script type="text/JavaScript">
-	<!--
-		function printit(){  
-		if (window.print) {
-			window.print() ;  
-		} else {
-			var WebBrowser = '<OBJECT ID="WebBrowser1" WIDTH=0 HEIGHT=0 CLASSID="CLSID:8856F961-340A-11D0-A96B-00C04FD705A2"></OBJECT>';
-		document.body.insertAdjacentHTML('beforeEnd', WebBrowser);
-			WebBrowser1.ExecWB(6, 2);
-		}
-		}
-		var win=null;
-		function NewWindow(mypage,myname,w,h,scroll,pos){
-		if(pos=="random"){LeftPosition=(screen.width)?Math.floor(Math.random()*(screen.width-w)):100;TopPosition=(screen.height)?Math.floor(Math.random()*((screen.height-h)-75)):100;}
-		if(pos=="center"){LeftPosition=(screen.width)?(screen.width-w)/2:100;TopPosition=(screen.height)?(screen.height-h)/2:100;}
-		else if((pos!="center" && pos!="random") || pos==null){LeftPosition=0;TopPosition=20}
-		settings='width='+w+',height='+h+',top='+TopPosition+',left='+LeftPosition+',scrollbars='+scroll+',location=no,directories=no,status=no,menubar=no,toolbar=no,resizable=yes';
-		win=window.open(mypage,myname,settings);}
-
-		function dontgo() {} 
-
-		function gotomenu(menu) {            
-			if (menu != "") {                    
-				self.location=menu; 
-			}
-		 }
-	-->
-	</script>
-
-</head>
-
-
-
-<body>
-
-<div id="container">
-	<div id="header">
-		
-			<h1><a href="/"><img src="/images/nav/logo.gif" alt="Public Building Commission of Chicago" width="281" height="91" /></a></h1>
-			
-		
-		<h2><img src="/images/banners/logan_library.jpg" width="563" height="91" alt="Logan Square Branch Library" /></h2>
-
-	</div>
-		
-	
-		
-	<div id="navBar">
-		<ul id="mainNav">
-			
-		<li><a href="/">Home</a></li>
-	
-		<li class="active"><a href="/content/about/">About The PBC</a></li>
-	
-		<li><a href="/content/projects/">PBC Projects</a></li>
-	
-		<li><a href="/content/working/">Doing Business With The PBC</a></li>
-	
-		<li><a href="/content/contact/">Contact The PBC</a></li>
-	
+<a href="https://www.linkedin.com/company/public-building-commission-of-chicago" target="_blank"><img src="/wp-content/uploads/SocialMedia/PBC_SocialMediaIcons_Linkedin.png" alt="LinkedIn" style="width:24px;height:24px;padding: 4px"></a></div>
+		</aside>		</div>
+	<div class="site-logo">
+			<a href="http://www.pbcchicago.com/" title="PBC Chicago" rel="home">
+				<img class="header-image" src="http://www.pbcchicago.com/wp-content/uploads/2016/11/WebLogo.jpg" alt="PBC Chicago" title="PBC Chicago" />
+			</a>
+		</div>					</div><!-- .inside-header -->
+	</header><!-- #masthead -->
+			<nav itemtype="http://schema.org/SiteNavigationElement" itemscope="itemscope" id="site-navigation" class="main-navigation">
+		<div class="inside-navigation grid-container grid-parent">
+						<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">
+								<span class="mobile-menu">Menu</span>
+			</button>
+			<div id="primary-menu" class="main-nav"><ul id="menu-main-nav" class=" menu sf-menu"><li id="menu-item-3711" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-3711"><a href="http://www.pbcchicago.com/projects/">Projects<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+<ul  class="sub-menu">
+	<li id="menu-item-87602" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-87602"><a href="http://www.pbcchicago.com/current-projects/">Current Projects</a></li>
+	<li id="menu-item-88694" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-88694"><a href="http://www.pbcchicago.com/projects-by-sister-agency/">Projects By Sister Agency<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-73191" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-73191"><a href="http://www.pbcchicago.com/projects-by-sister-agency/chicago-park-district/">Chicago Park District</a></li>
+		<li id="menu-item-73189" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-73189"><a href="http://www.pbcchicago.com/projects-by-sister-agency/chicago-public-libraries/">Chicago Public Libraries</a></li>
+		<li id="menu-item-73193" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-73193"><a href="http://www.pbcchicago.com/projects-by-sister-agency/cps/">Chicago Public Schools</a></li>
+		<li id="menu-item-88674" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88674"><a href="http://www.pbcchicago.com/projects-by-sister-agency/cta/">Chicago Transit Authority</a></li>
+		<li id="menu-item-73192" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-73192"><a href="http://www.pbcchicago.com/projects-by-sister-agency/city-colleges-chicago/">City Colleges of Chicago</a></li>
+		<li id="menu-item-73190" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-73190"><a href="http://www.pbcchicago.com/projects-by-sister-agency/city-of-chicago/">City of Chicago</a></li>
+		<li id="menu-item-88604" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88604"><a href="http://www.pbcchicago.com/projects-by-sister-agency/chicago-police-department/">Chicago Police Department</a></li>
+		<li id="menu-item-73198" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-73198"><a href="http://www.pbcchicago.com/projects-by-sister-agency/chicago-fire-department/">Chicago Fire Department</a></li>
+	</ul>
+</li>
+	<li id="menu-item-88607" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88607"><a href="http://www.pbcchicago.com/project-search/">Project Search</a></li>
+</ul>
+</li>
+<li id="menu-item-809" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-809"><a href="http://www.pbcchicago.com/doing-business/">Doing Business<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+<ul  class="sub-menu">
+	<li id="menu-item-2368" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-2368"><a href="#">Working with the PBC<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-87597" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-87597"><a href="http://www.pbcchicago.com/doing-business/community-hiring-events/">Community Hiring Events</a></li>
+		<li id="menu-item-51344" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-51344"><a href="http://www.pbcchicago.com/doing-business/general-contractors/">General Contractors</a></li>
+		<li id="menu-item-2553" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2553"><a href="http://www.pbcchicago.com/doing-business/architects-of-record/">Architects of Record</a></li>
+		<li id="menu-item-2554" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2554"><a href="http://www.pbcchicago.com/doing-business/engineering-services/">Engineering Services</a></li>
+		<li id="menu-item-2555" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2555"><a href="http://www.pbcchicago.com/doing-business/professional-service-providers/">Professional Service Providers</a></li>
+		<li id="menu-item-86168" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-86168"><a href="http://www.pbcchicago.com/doing-business/subcontractors-subconsultants/">Subcontractors &#038; Subconsultants</a></li>
+		<li id="menu-item-2556" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2556"><a href="http://www.pbcchicago.com/doing-business/mbeswbes/">Minority Business Enterprise / Women’s Business Enterprise</a></li>
+		<li id="menu-item-2733" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2733"><a href="http://www.pbcchicago.com/doing-business/contractforms/">General Contractors Contract Forms</a></li>
+	</ul>
+</li>
+	<li id="menu-item-1804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1804"><a href="http://www.pbcchicago.com/doing-business/current-opportunities/">Current Opportunities</a></li>
+	<li id="menu-item-72953" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-72953"><a href="http://www.pbcchicago.com/past-alerts/">PBC Alerts</a></li>
+	<li id="menu-item-2100" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-2100"><a href="#">Prequalification<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-26349" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26349"><a href="http://www.pbcchicago.com/doing-business/prequalified-general-contractors/">Prequalified General Contractors</a></li>
+		<li id="menu-item-26348" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-26348"><a href="http://www.pbcchicago.com/doing-business/prequalified-specialty-contractors/">Prequalified Specialty Contractors</a></li>
+	</ul>
+</li>
+	<li id="menu-item-51345" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-51345"><a href="#">Awarded Contracts<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-72175" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-72175"><a href="http://www.pbcchicago.com/doing-business/contracts-awarded/">Contract Search</a></li>
+		<li id="menu-item-72173" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-72173"><a href="http://www.pbcchicago.com/doing-business/bid-tabulations/">Bid Tabulations</a></li>
+	</ul>
+</li>
+</ul>
+</li>
+<li id="menu-item-997" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-997"><a href="#">About<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+<ul  class="sub-menu">
+	<li id="menu-item-2508" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2508"><a href="http://www.pbcchicago.com/whoispbc/">Who is the PBC?<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-72284" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-72284"><a href="http://www.pbcchicago.com/whoispbc/executivedirector/">Executive Director Carina E. Sánchez</a></li>
+		<li id="menu-item-87773" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-87773"><a href="http://www.pbcchicago.com/whoispbc/our-team/">Our Team</a></li>
+		<li id="menu-item-1010" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1010"><a href="http://www.pbcchicago.com/whoispbc/mission-vision/">Mission &#038; Vision</a></li>
+		<li id="menu-item-2509" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2509"><a href="http://www.pbcchicago.com/whoispbc/historicalhighlights/">Historical Highlights</a></li>
+	</ul>
+</li>
+	<li id="menu-item-1012" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-1012"><a href="#">Our Board<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-1023" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1023"><a href="http://www.pbcchicago.com/chairman/">Chairman: Mayor Rahm Emanuel</a></li>
+		<li id="menu-item-1022" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1022"><a href="http://www.pbcchicago.com/commissioners/">Commissioners</a></li>
+		<li id="menu-item-1013" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-1013"><a href="#">Meetings<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+		<ul  class="sub-menu">
+			<li id="menu-item-86502" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-86502"><a href="http://www.pbcchicago.com/board-meetings/">Board Meetings</a></li>
+			<li id="menu-item-1982" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1982"><a href="http://www.pbcchicago.com/audit-committee-meetings/">Audit Committee Meetings</a></li>
+			<li id="menu-item-2562" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2562"><a href="http://www.pbcchicago.com/administrative-operations-committee-meetings/">Administrative Operations Committee Meetings</a></li>
+			<li id="menu-item-51260" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-51260"><a href="http://www.pbcchicago.com/pbc-comments-registration/">Public Comments</a></li>
 		</ul>
-		
-		<div id="search">
-			<form action="http://www.pbcchicago.com/content/search/default.asp" id="cse-search-box">
-			<input type="hidden" name="cx" value="007739507344007805884:ix9hqnpryno" />
-			<input type="hidden" name="cof" value="FORID:11" />
-			<input type="hidden" name="ie" value="UTF-8" />
-			<ul>
-				<li><input class="input" type="text" name="q" /></li>
-				<li><input class="button" type="submit" name="sa" value="Search" /></li>
-			</ul>
-			</form>
-			<script type="text/javascript" src="http://www.google.com/coop/cse/brand?form=cse-search-box&lang=en"></script>
-		</div>
-		
-		<div class="clear"></div>
+</li>
+	</ul>
+</li>
+	<li id="menu-item-1984" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1984"><a href="http://www.pbcchicago.com/press-releases/">Press Releases</a></li>
+	<li id="menu-item-88798" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88798"><a href="http://www.pbcchicago.com/newsletter/">Newsletter</a></li>
+	<li id="menu-item-2091" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2091"><a href="http://www.pbcchicago.com/awards_recognition/">Awards &#038; Recognition</a></li>
+</ul>
+</li>
+<li id="menu-item-88695" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-88695"><a href="#">Resources<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+<ul  class="sub-menu">
+	<li id="menu-item-1180" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-1180"><a href="#">Reports<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-1182" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1182"><a href="http://www.pbcchicago.com/resources/annual-reports/">Annual Reports</a></li>
+		<li id="menu-item-1181" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1181"><a href="http://www.pbcchicago.com/resources/financial-reports/">Financial Reports</a></li>
+		<li id="menu-item-1920" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1920"><a href="http://www.pbcchicago.com/resources/staff-reports/">Staff Reports</a></li>
+		<li id="menu-item-1209" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1209"><a href="http://www.pbcchicago.com/resources/other-reports/">Other Reports</a></li>
+		<li id="menu-item-51346" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-51346"><a href="http://www.pbcchicago.com/resources/videos/">Videos</a></li>
+	</ul>
+</li>
+	<li id="menu-item-2558" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-has-children menu-item-2558"><a href="http://www.pbcchicago.com/resources/pbc-archives/">PBC Archives<span role="button" class="dropdown-menu-toggle" aria-expanded="false"></span></a>
+	<ul  class="sub-menu">
+		<li id="menu-item-88661" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88661"><a href="http://www.pbcchicago.com/resources/pbc-archives/community-meetings/">Community Meetings</a></li>
+		<li id="menu-item-88618" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88618"><a href="http://www.pbcchicago.com/resources/pbc-archives/environmental-guidelines/">Environmental Guidelines</a></li>
+		<li id="menu-item-88615" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88615"><a href="http://www.pbcchicago.com/resources/pbc-archives/leed-downloads/">LEED Downloads</a></li>
+		<li id="menu-item-88596" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-88596"><a href="http://www.pbcchicago.com/resources/pbc-archives/sub-contractor-updates/">Subcontractor Updates</a></li>
+	</ul>
+</li>
+	<li id="menu-item-2081" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-2081"><a href="http://www.pbcchicago.com/foia/">Freedom of Information Act</a></li>
+</ul>
+</li>
+<li id="menu-item-86367" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-86367"><a href="http://www.pbcchicago.com/search-page/">Search</a></li>
+</ul></div>		</div><!-- .inside-navigation -->
+	</nav><!-- #site-navigation -->
+		<div class="grid-container grid-parent">
+		<div class="page-header">
+			<p id="breadcrumbs"><span xmlns:v="http://rdf.data-vocabulary.org/#"><span typeof="v:Breadcrumb"><a href="http://www.pbcchicago.com/" rel="v:url" property="v:title">Home</a> » <span rel="v:child" typeof="v:Breadcrumb"><a href="http://www.pbcchicago.com/events/event/" rel="v:url" property="v:title">Events</a> » <strong class="breadcrumb_last">Pre-Bid Meeting &#8211; Chicago Park District Group B (C1595)</strong></span></span></span></p>		</div>
 	</div>
-
 	
-		<div id="content">
-	
-
-		<div id="secondary">
-			<ul id="subNav">
-				
-			<li class="naHeader">
-		
-		<a href="/content/about/default.asp">About The PBC</a>
-		
-		
-	</li>
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/rahm_emanuel.asp">PBC Chairman</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/comissioners.asp">Board of Commissioners</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/carina_sanchez.asp">PBC Executive Director</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/mission_vision.asp">Mission and Vision</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/annual_reports.asp">Annual Reports</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/financial_reports.asp">Financial Reports</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/staff_reports.asp">Staff Reports</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/monthly_reports.asp">Monthly Reports</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/other_reports.asp">Other Reports</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/press_releases.asp">Press Releases</a>
-		
-		
-	</li>
-	
-
-
-	<li style="border:none;">&nbsp;</li>
-
-			<li class="aHeader">
-		
-		<a href="/content/about/calendar.asp">Agendas, Minutes & Notices</a>
-		
-		
-	</li>
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/calendar_types.asp?tID=2">PBC Board</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/calendar_types.asp?tID=3">Audit Committee</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/calendar_types.asp?tID=4">Administrative Operations</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/public_comments.asp">Public Comments</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/calendar_types.asp?tID=10">Community Meetings</a>
-		
-		
-	</li>
-	
-
-
-	<li style="border:none;">&nbsp;</li>
-
-			<li class="naHeader">
-		PBC Board Actions	
-		
-	</li>
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/boardaction_view.asp?ACT_ID=GC">General Contractors Named</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/boardaction_view.asp?ACT_ID=AR">Architects Named</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/boardaction_view.asp?ACT_ID=DB">Design-Builder Named</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/boardaction_view.asp?ACT_ID=PS">Professional Service Contracts</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/boardaction_view.asp?ACT_ID=CO">Change Orders</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/boardaction_view.asp?ACT_ID=CA">Contract Amendments</a>
-		
-		
-	</li>
-	
-
-
-			<li class="naLink">
-		
-		<a href="/content/about/boardaction_view.asp?ACT_ID=OA">Other Actions</a>
-		
-		
-	</li>
-	
-
-
-	<li style="border:none;">&nbsp;</li>
-
-			<li class="naHeader">
-		
-		<a href="/content/about/sister_agencies.asp">Sister Agencies</a>
-		
-		
-	</li>
-
-
-	<li><a href="http://www.cityofchicago.org/" target="_blank">City of Chicago</a></li>
-
-	<li><a href="http://www.cps.edu/" target="_blank">Chicago Public Schools</a></li>
-
-	<li><a href="http://www.chipublib.org/" target="_blank">Chicago Public Library</a></li>
-
-	<li><a href="http://www.chicagoparkdistrict.com/" target="_blank">Chicago Park District</a></li>
-
-	<li><a href="http://www.ccc.edu/" target="_blank">City Colleges of Chicago</a></li>
-
-	<li><a href="http://www.cookcountyil.gov/" target="_blank">Cook County</a></li>
-
-	<li><a href="http://www.fpdcc.com/" target="_blank">Forest Preserve District</a></li>
-
-	<li><a href="http://www.transitchicago.com/" target="_blank">Chicago Transit Authority</a></li>
-
-	<li><a href="http://www.thecha.org/" target="_blank">Chicago Housing Authority</a></li>
-
-	<li><a href="http://www.mwrd.org/" target="_blank">Metropolitan Water Reclamation District</a></li>
-
-	<li><a href="http://www.mpea.com/" target="_blank">Metropolitan Pier and Exposition Authority</a></li>
-
-			</ul>
-		
-		</div>
-	
-		<div id="main">
-	
-	
-
-    <div id="breadcrumb">
-		<a href="/">Home</a> / <a href="/content/about/">About the PBC</a> / PBC Calendar
-	</div>
-
-	<h1>PBC Calendar</h1>
-	
-	
-    <div id="bbox">
-		<div id="title">CALENDAR</div>
-		<div id="contentArea">
-	    	<div>
-	    		<table>
-				<tr>
-				<th style="text-align:left;"><a href="/content/about/calendar.asp?myDate=9/1/2017" class="h3">&lt; PREV</a></th>
-				<th style="text-align:center; font-weight:bold;">October&nbsp;2017</th>
-				<th style="text-align:right;"><a href="/content/about/calendar.asp?myDate=11/1/2017" class="h3">NEXT &gt;</a></th>
-				</tr>
-				</table>
-			</div>
+	<div id="page" class="hfeed site grid-container container grid-parent">
+		<div id="content" class="site-content">
 			
-			<div>
-				<table>
-				<tr>
-				<td class="calday">Sunday</td>
-				<td class="calday">Monday</td>
-				<td class="calday">Tuesday</td>
-				<td class="calday">Wednesday</td>
-				<td class="calday">Thursday</td>
-				<td class="calday">Friday</td>
-				<td class="calday">Saturday</td>	
-				</tr>
+	<div id="primary" class="content-area grid-parent mobile-grid-100 grid-100 tablet-grid-100">
+		<main id="main" class="site-main">
 				
-				<tr style="height:100px;">
-						
-						</tr>
-						<tr style="height:100px;">
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">1</div>
-						
-						
+			
+<article id="post-88782" class="post-88782 event type-event status-publish format-standard hentry event-venue-mckinley-park-auditorium event-category-opportunity" itemtype='http://schema.org/CreativeWork' itemscope='itemscope'>
+	<div class="inside-article">
+				
+		<header class="entry-header">
+										<h1 class="entry-title" itemprop="headline">Pre-Bid Meeting &#8211; Chicago Park District Group B (C1595)</h1>								</header><!-- .entry-header -->
+		
+				<div class="entry-content" itemprop="text">
+			
+<div class="eventorganiser-event-meta">
+
+	<hr>
+
+	<!-- Event details -->
+	<h4>Event Details</h4>
+
+	<!-- Is event recurring or a single event -->
+	
+	<ul class="eo-event-meta">
+
+					<!-- Single event -->
+			<li><strong>Date:</strong> <time itemprop="startDate" datetime="2018-02-21T09:30:00-06:00">February 21, 2018 9:30 am</time> &ndash; <time itemprop="endDate" datetime="2018-02-21T13:00:00-06:00">1:00 pm</time></li>
+		
+					<li><strong>Venue:</strong> <a href="http://www.pbcchicago.com/events/venues/mckinley-park-auditorium/"> McKinley Park Auditorium</a></li>
+		
+					<li><strong>Categories:</strong> <a href="http://www.pbcchicago.com/events/category/opportunity/" rel="tag">Opportunity</a></li>
+		
+		
+		
+		
+	</ul>
+
+	<!-- Does the event have a venue? -->
+			<!-- Display map -->
+		<div class="eo-event-venue-map">
+			<div class='eo-venue-map googlemap' id='eo_venue_map-3' style='height:200px;width:100%;' ></div>		</div>
+	
+
+	<div style="clear:both"></div>
+
+	<hr>
+
+</div><!-- .entry-meta -->
+<p>On <strong>Wednesday, February 21, 2018</strong>, in the McKinley Park Auditorium, located at 2210 West Pershing Road, Chicago, Illinois 60609, PBC will host a <strong>Pre-Bid Meeting at 9:30 a.m.</strong>, a <strong>Mandatory Technical Review Meeting at 10:00a.m., and a Non-Mandatory Site Visit at 12:00p.m.</strong> Attendees are to enter through (North) Main Entrance.  Parking is available in the parking lot adjacent to the McKinley Park Fieldhouse.</p>
+<p><a href="http://www.pbcchicago.com/opportunities/chicago-park-district-group-b-c1595/">Details here.</a></p>
+					</div><!-- .entry-content -->
+		
+					</div><!-- .inside-article -->
+</article><!-- #post-## -->
+			
+			
+						</main><!-- #main -->
+	</div><!-- #primary -->
 
 
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">2</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2166"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
+	</div><!-- #content -->
+</div><!-- #page -->
+<div class="site-footer  ">
+			<div id="footer-widgets" class="site footer-widgets">
+			<div class="footer-widgets-container grid-container grid-parent">
+				<div class="inside-footer-widgets">
+											<div class="footer-widget-1 grid-parent grid-33 tablet-grid-50 mobile-grid-100">
+							<aside id="nav_menu-3" class="widget inner-padding widget_nav_menu"><h4 class="widget-title">QUICK LINKS</h4><div class="menu-footer-left-navigation-container"><ul id="menu-footer-left-navigation" class="menu"><li id="menu-item-1070" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1070"><a href="http://www.pbcchicago.com/foia/">Freedom of Information Act</a></li>
+<li id="menu-item-1248" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1248"><a href="http://www.pbcchicago.com/pbc-comments-registration/">Public Comments Registration</a></li>
+<li id="menu-item-1262" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1262"><a href="http://www.pbcchicago.com/careers/">Careers</a></li>
+<li id="menu-item-1255" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1255"><a href="http://www.pbcchicago.com/oig-compliant-hotline/">OIG Complaint Hotline</a></li>
+<li id="menu-item-72188" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-72188"><a href="http://www.pbcchicago.com/ethics-policy/">Ethics Policy</a></li>
+</ul></div></aside>						</div>
+										<div class="footer-widget-2 grid-parent grid-33 tablet-grid-50 mobile-grid-100">
+						<aside id="text-6" class="widget inner-padding widget_text"><h4 class="widget-title">GET CONNECTED</h4>			<div class="textwidget"><div class="socialMedia-icons"><a href="http://www.facebook.com/pages/Public-Building-Commission-of-Chicago/218267174868954" target="_blank"><img src="/wp-content/uploads/SocialMedia/PBC_SocialMediaIcons_Facebook.png" alt="Facebook" style="width:36px;height:36px; padding: 4px"></a>
+
+<a href="http://www.twitter.com/PBCChi" target="_blank"><img src="/wp-content/uploads/SocialMedia/PBC_SocialMediaIcons_Twitter.png" alt="Twitter" style="width:36px;height:36px;padding: 4px"></a>
+
+<a href="http://www.flickr.com/photos/pbcchicago" target="_blank"><img src="/wp-content/uploads/SocialMedia/PBC_SocialMediaIcons_Flickr.png" alt="Flickr" style="width:36px;height:36px;padding: 4px"></a>
+
+<a href="https://www.youtube.com/watch?v=unNk6NZMkAI" target="_blank"><img src="/wp-content/uploads/SocialMedia/PBC_SocialMediaIcons_Youtube.png" alt="YouTube" style="width:36px;height:36px;padding: 4px"></a>
+</div>
+		</aside>					</div>
+										<div class="footer-widget-3 grid-parent grid-33 tablet-grid-50 mobile-grid-100">
+						<aside id="text-4" class="widget inner-padding widget_text"><h4 class="widget-title">CONTACT</h4>			<div class="textwidget"><p>Public Building Commission<br>
+Richard J. Daley Center <br>
+50 West Washington Street, Room 200<br>
+Chicago, Illinois 60602<br>
+312.744.3090  |  <a href="mailto:pbc@pbcchicago.com" target="_blank">pbc@pbcchicago.com</a></p></div>
+		</aside>					</div>
 									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=1992"><b>Board Meeting</b></a><br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											2:30PM
-										</div>
-										
-										
-												<div style="padding:0 0 5px 0;">
-												
-														<a target="_blank" href="/upload_events/DOC_995_file.pdf">Agenda </a><br />
-													
-														<a target="_blank" href="/upload_events/DOC_997_file.pdf">Summary</a><br />
-													
-														<a target="_blank" href="/upload_events/DOC_998_file.pdf">Presentation</a><br />
-													
-												</div>
-											
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">3</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2167"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">4</div>
-						
-						
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">5</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2169"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=502"><b>AFB</b></a><br />
-										
-											(Read Dunning - Site Preparation )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2073"><b>Daley Plaza</b></a><br />
-										
-											(Farmers Market)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											7:00AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">6</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2170"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=502"><b>AFB</b></a><br />
-										
-											(Read Dunning - Site Preparation )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											11:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2164"><b>Community Hiring</b></a><br />
-										
-											(South Loop Elementary School Community Hiring Event)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-												<div style="padding:0 0 5px 0;">
-												
-														<a target="_blank" href="/upload_events/DOC_986_file.pdf">Hiring Event Flyer</a><br />
-													
-												</div>
-											
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2095"><b>Daley Plaza</b></a><br />
-										
-											(Food Truck Fests)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											11:00AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">7</div>
-						
-						
-
-
-					</td>
-							
-						</tr>
-						<tr style="height:100px;">
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">8</div>
-						
-						
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">9</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2171"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2042"><b>Holiday</b></a><br />
-										
-											(Columbus Day)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											8:00AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">10</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2172"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">11</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2173"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">12</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2174"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2074"><b>Daley Plaza</b></a><br />
-										
-											(Farmers Market)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											7:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2165"><b>Community Hiring</b></a><br />
-										
-											(South Loop Elementary School Hiring Event)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-												<div style="padding:0 0 5px 0;">
-												
-														<a target="_blank" href="/upload_events/DOC_987_file.pdf">Hiring Event Flyer</a><br />
-													
-												</div>
-											
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayold">
-							
-					
-					
-					<div class="calnumber">13</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2175"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2191"><b>Community Hiring</b></a><br />
-										
-											(Ebinger Community Hiring Event)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-												<div style="padding:0 0 5px 0;">
-												
-														<a target="_blank" href="/upload_events/DOC_999_file.pdf">Ebinger Community Hiring Event Flyer</a><br />
-													
-												</div>
-											
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2096"><b>Daley Plaza</b></a><br />
-										
-											(Food Truck Fests)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											11:00AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="caldayactive">
-							
-					
-					
-					<div class="calnumber">14</div>
-						
-						
-
-
-					</td>
-							
-						</tr>
-						<tr style="height:100px;">
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">15</div>
-						
-						
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">16</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2176"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">17</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2177"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">18</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2178"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=503"><b>AFB</b></a><br />
-										
-											(<br/>Ebinger Elementary School Annex )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=503"><b>AFB</b></a><br />
-										
-											(<br/>Ebinger Elementary School Annex )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:30AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">19</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2179"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=504"><b>AFB</b></a><br />
-										
-											(<br/>Mt. Greenwood Elementary School Annex II  )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=504"><b>AFB</b></a><br />
-										
-											(<br/>Mt. Greenwood Elementary School Annex II  )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:30AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2075"><b>Daley Plaza</b></a><br />
-										
-											(Farmers Market)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											7:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2192"><b>Board Meeting</b></a><br />
-										
-											(Special Board Meeting)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											2:30PM
-										</div>
-										
-										
-												<div style="padding:0 0 5px 0;">
-												
-														<a target="_blank" href="/upload_events/DOC_1000_file.pdf">Notice</a><br />
-													
-												</div>
-											
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">20</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2180"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2097"><b>Daley Plaza</b></a><br />
-										
-											(Food Truck Fests)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											11:00AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">21</div>
-						
-						
-
-
-					</td>
-							
-						</tr>
-						<tr style="height:100px;">
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">22</div>
-						
-						
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">23</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2181"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">24</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2182"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=501"><b>AFB</b></a><br />
-										
-											(Lake View High School Renovation Rebid 4015 N. Ashland Avenue )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											11:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2189"><b>Community Hiring</b></a><br />
-										
-											(Community Hiring Event - Sheridan Math & Science Academy Annex)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-												<div style="padding:0 0 5px 0;">
-												
-														<a target="_blank" href="/upload_events/DOC_993_file.pdf">Sheridan Math & Science Academy Annex Hiring Event Flyer</a><br />
-													
-												</div>
-											
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">25</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2183"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2098"><b>Daley Plaza</b></a><br />
-										
-											(Food Truck Fests)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											11:00AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">26</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2184"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/working/opening_display.asp?BID_ID=502"><b>AFB</b></a><br />
-										
-											(Read Dunning - Site Preparation )<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											11:00AM
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2076"><b>Daley Plaza</b></a><br />
-										
-											(Farmers Market)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											7:00AM
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">27</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2185"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">28</div>
-						
-						
-
-
-					</td>
-							
-						</tr>
-						<tr style="height:100px;">
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">29</div>
-						
-						
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">30</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2186"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2190"><b>Community Hiring</b></a><br />
-										
-											(Community Hiring Event - Sheridan Math & Science Academy Annex)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											10:00AM
-										</div>
-										
-										
-												<div style="padding:0 0 5px 0;">
-												
-														<a target="_blank" href="/upload_events/DOC_994_file.pdf">Sheridan Math & Science Academy Annex Hiring Event Flyer</a><br />
-													
-												</div>
-											
-									</div>
-								
-
-
-					</td>
-					
-								<td class="calday2">
-							
-					
-					
-					<div class="calnumber">31</div>
-						
-						
-									<div style="text-align:center;">
-										
-											<a href="/content/about/calendar_detail.asp?eID=2187"><b>Daley Plaza</b></a><br />
-										
-											(Italian Exhibit)<br />
-										
-										
-										<div style="padding:3px 0 5px 0;">
-											
-										</div>
-										
-										
-									</div>
-								
-
-
-					</td>
-					
-				</tr>
-				</table>
 			</div>
 		</div>
-	</div>
-
-	
-	
-	<div id="acrobat"><a style="border-bottom:0;" href="http://www.adobe.com/products/acrobat/readstep2.html"><img src="/images/pics/get_adobe_reader.gif" width="112" height="33" alt="Get Acrobat Reader" /></a></div>
-
+		<footer class="site-info" itemtype="http://schema.org/WPFooter" itemscope="itemscope">
+		<div class="inside-site-info grid-container grid-parent">
+						<div class="copyright-bar">
+				    Copyright &copy; 2018 Public Building Commission of Chicago. All Rights Reserved. The PBC logo is a trademark of the Public Building Commission of Chicago. <a href="/legal-notice/">Legal Notice</a>.
 			</div>
 		</div>
-		<div class="clear"></div>
-	</div>
-	
-	
-		<div id="share">
-			<a href="#" onclick="printit()" class="print">Print This Page</a>
-		</div>
-	
+	</footer><!-- .site-info -->
+	</div><!-- .site-footer -->
 
-	<div id="footer">
-		<div>Copyright &copy; 2017 Public Building Commission of Chicago. All Rights Reserved. <a href="/content/contact/legal_notice.asp">Legal Notice</a>.</div>
-		<div>The PBC logo is a trademark of the Public Building Commission of Chicago.</div>
-	</div>
+<link rel='stylesheet' id='eo_front-css'  href='http://www.pbcchicago.com/wp-content/plugins/event-organiser/css/eventorganiser-front-end.min.css?ver=3.5.1' type='text/css' media='all' />
+<link rel='stylesheet' id='eo_calendar-style-css'  href='http://www.pbcchicago.com/wp-content/plugins/event-organiser/css/fullcalendar.min.css?ver=3.5.1' type='text/css' media='all' />
+<script type='text/javascript'>
+/* <![CDATA[ */
+var scriptParams = {"google_search_engine_id":"009064753142514980522:hymho0lxgao"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/wp-google-search/assets/js/google_cse_v2.js?ver=1'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var ctf = {"ajax_url":"http:\/\/www.pbcchicago.com\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/custom-twitter-feeds/js/ctf-scripts.js?ver=1.2.7'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/revslider/public/assets/js/jquery.themepunch.tools.min.js'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/revslider/public/assets/js/jquery.themepunch.revolution.min.js'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/themes/generatepress-child/js/pbc-projects.js'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/themes/generatepress/js/navigation.min.js?ver=1.3.46'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/themes/generatepress/js/dropdown.min.js?ver=1.3.46'></script>
+<!--[if lt IE 9]>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/themes/generatepress/js/html5shiv.min.js?ver=1.3.46'></script>
+<![endif]-->
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-includes/js/wp-embed.min.js?ver=4.8.5'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/event-organiser/js/qtip2.js?ver=3.5.1'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-includes/js/jquery/ui/core.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-includes/js/jquery/ui/widget.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-includes/js/jquery/ui/button.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-includes/js/jquery/ui/datepicker.min.js?ver=1.11.4'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/event-organiser/js/moment.min.js?ver=1'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/event-organiser/js/fullcalendar.min.js?ver=3.5.1'></script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/event-organiser/js/event-manager.min.js?ver=3.5.1'></script>
+<script type='text/javascript'>
+/* <![CDATA[ */
+var EOAjaxFront = {"adminajax":"http:\/\/www.pbcchicago.com\/wp-admin\/admin-ajax.php","locale":{"locale":"en","isrtl":false,"monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthAbbrev":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayAbbrev":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayInitial":["S","M","T","W","T","F","S"],"ShowMore":"Show More","ShowLess":"Show Less","today":"today","day":"day","week":"week","month":"month","gotodate":"go to date","cat":"View all categories","venue":"View all venues","tag":"View all tags","view_all_organisers":"View all organisers","nextText":">","prevText":"<"}};
+var eventorganiser = {"ajaxurl":"http:\/\/www.pbcchicago.com\/wp-admin\/admin-ajax.php","calendars":[],"widget_calendars":[],"fullcal":[],"map":[{"zoom":15,"minzoom":0,"maxzoom":null,"zoomcontrol":true,"scrollwheel":true,"rotatecontrol":true,"maptypecontrol":true,"pancontrol":true,"overviewmapcontrol":true,"streetviewcontrol":true,"draggable":true,"maptypeid":"ROADMAP","width":"100%","height":"200px","class":"","tooltip":true,"styles":[],"locations":[{"venue_id":117,"lat":"41.823738","lng":"-87.682445","tooltipContent":"<strong>McKinley Park Auditorium<\/strong><br \/>2210 West Pershing Road, Chicago, IL, 60609, USA","icon":null}]},{"zoom":15,"minzoom":0,"maxzoom":null,"zoomcontrol":true,"scrollwheel":true,"rotatecontrol":true,"maptypecontrol":true,"pancontrol":true,"overviewmapcontrol":true,"streetviewcontrol":true,"draggable":true,"maptypeid":"ROADMAP","width":"100%","height":"200px","class":"","tooltip":true,"styles":[],"locations":[{"venue_id":117,"lat":"41.823738","lng":"-87.682445","tooltipContent":"<strong>McKinley Park Auditorium<\/strong><br \/>2210 West Pershing Road, Chicago, IL, 60609, USA","icon":null}]},{"zoom":15,"minzoom":0,"maxzoom":null,"zoomcontrol":true,"scrollwheel":true,"rotatecontrol":true,"maptypecontrol":true,"pancontrol":true,"overviewmapcontrol":true,"streetviewcontrol":true,"draggable":true,"maptypeid":"ROADMAP","width":"100%","height":"200px","class":"","tooltip":true,"styles":[],"locations":[{"venue_id":117,"lat":"41.823738","lng":"-87.682445","tooltipContent":"<strong>McKinley Park Auditorium<\/strong><br \/>2210 West Pershing Road, Chicago, IL, 60609, USA","icon":null}]}]};
+/* ]]> */
+</script>
+<script type='text/javascript' src='http://www.pbcchicago.com/wp-content/plugins/event-organiser/js/frontend.min.js?ver=3.5.1'></script>
+<script type='text/javascript' src='http://maps.googleapis.com/maps/api/js?language=en&#038;ver=4.8.5'></script>
 
-	</body>
-	</html>
+</body>
+</html>

--- a/tests/files/chi_buildings.json
+++ b/tests/files/chi_buildings.json
@@ -1,0 +1,1094 @@
+[
+    {
+        "title": "New Year\u2019s Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/new-years-day-13\/",
+        "allDay": true,
+        "start": "2018-01-01T00:00:00",
+        "end": "2018-01-02T00:00:00",
+        "description": "January 1, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-past",
+            "eo-all-day",
+            "eo-event",
+            "eo-past-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 January 4, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-january-4-2018\/",
+        "allDay": false,
+        "start": "2018-01-04T13:00:00",
+        "end": "2018-01-04T14:00:00",
+        "description": "January 4, 2018  1:00 pm - 2:00 pm<\/br><\/br>Agenda\u00a0",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Community Hiring Event: Daley College EAMC",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/community-hiring-event-daley-college-eamc\/",
+        "allDay": false,
+        "start": "2018-01-05T10:30:00",
+        "end": "2018-01-05T15:30:00",
+        "description": "January 5, 2018  10:30 am - 3:30 pm<\/br><\/br>Apply to work on the construction of the Engineering &amp; Advanced Manufacturing Center at Richard J. Daley College. Event flyer Friday, January 5, 2018 10:30 AM - 3:30 PM DALEY COLLEGE, ROOM 1205 7500 S PULASKI RD CHICAGO &nbsp;",
+        "organiser": 3,
+        "className": [
+            "eo-event-venue-daley-college",
+            "eo-event-cat-community-hiring",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "venue-daley-college",
+            "category-community-hiring"
+        ],
+        "venue": 116,
+        "venue_slug": "daley-college",
+        "category": [
+            "community-hiring"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#112e51"
+    },
+    {
+        "title": "Board Meeting \u2013 January 9, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-january-9-2018\/",
+        "allDay": false,
+        "start": "2018-01-09T14:30:00",
+        "end": "2018-01-09T15:30:00",
+        "description": "January 9, 2018  2:30 pm - 3:30 pm<\/br><\/br>[vc_row][vc_column][vc_empty_space height=\"16px\"][vc_column_text] Second Floor Board Room Richard J. Daley Center 50 West Washington Street [\/vc_column_text][\/vc_column][\/vc_row][vc_row][vc_column][vc_text_separator title=\"Board Material\"][\/vc_column][\/vc_row][vc_row][vc_column width=\"1\/4\"][vc_btn title=\"Agenda\" style=\"outline-custom\" outline_custom_color=\"#d51f35\" outline_custom_hover_background=\"#d51f35\" outline_custom_hover_text=\"#ffffff\" align=\"center\" link=\"url:http%3A%2F%2Fwww.pbcchicago.com%2Fwp-content%2Fuploads%2F2017%2F12%2FMA_PBC_MPW_bdgeneral20180109.pdf|title:Agenda|target:%20_blank|\" button_block=\"true\"][\/vc_column][vc_column width=\"1\/4\"][vc_btn title=\"Presentation\" style=\"outline-custom\" outline_custom_color=\"#d51f35\" outline_custom_hover_background=\"#d51f35\" outline_custom_hover_text=\"#ffffff\" align=\"center\" link=\"url:http%3A%2F%2Fwww.pbcchicago.com%2Fwp-content%2Fuploads%2F2017%2F12%2FBoardPresentation_20180109web.pdf|title:Presentation|target:%20_blank|\" button_block=\"true\"][\/vc_column][vc_column width=\"1\/4\"][vc_btn title=\"Summary\" style=\"outline-custom\" outline_custom_color=\"#d51f35\" outline_custom_hover_background=\"#d51f35\" outline_custom_hover_text=\"#ffffff\" align=\"center\" link=\"url:http%3A%2F%2Fwww.pbcchicago.com%2Fwp-content%2Fuploads%2F2018%2F01%2FBoard-Summary.pdf|title:Summary|target:%20_blank|\" button_block=\"true\"][\/vc_column][vc_column width=\"1\/4\"][vc_btn title=\"Minutes\" style=\"outline-custom\" outline_custom_color=\"#d51f35\" outline_custom_hover_background=\"#d51f35\" outline_custom_hover_text=\"#ffffff\" align=\"center\" link=\"url:http%3A%2F%2Fwww.pbcchicago.com%2Fwp-content%2Fuploads%2F2018%2F02%2FMMR_PBC_JANUARYMINUTES_20180109.pdf|title:Minutes|target:%20_blank|\" button_block=\"true\"][\/vc_column][\/vc_row][vc_row][vc_column][vc_text_separator title=\"Board Actions\"][vc_tta_tabs...",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Pre-Bid Meeting \u2013 Columbia Explorers Elementary School Annex",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/pre-bid-meeting\/",
+        "allDay": false,
+        "start": "2018-01-11T10:00:00",
+        "end": "2018-01-11T12:00:00",
+        "description": "January 11, 2018  10:00 am - 12:00 pm<\/br><\/br>On Thursday, January 11, 2018, at the Columbia Explorers Elementary School Annex, located at 4520 S. Kedzie Avenue, Chicago, IL, PBC will host a Pre-Bid Meeting at 10:00 a.m., a Mandatory Technical Review Meeting at 10:30a.m., and a Mandatory Site Visit at 11:00a.m. The Technical Review Meeting is mandatory for all eligible, prequalified firms interested...",
+        "organiser": 5,
+        "className": [
+            "eo-event-cat-opportunity",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "category-opportunity"
+        ],
+        "category": [
+            "opportunity"
+        ],
+        "tags": [],
+        "textColor": "#000000",
+        "color": "#f27602"
+    },
+    {
+        "title": "Community Hiring Event:\u00a0Prussing Elementary School Annex",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/community-hiring-event-prussing-elementary-school-annex-2\/",
+        "allDay": false,
+        "start": "2018-01-12T10:30:00",
+        "end": "2018-01-12T14:30:00",
+        "description": "January 12, 2018  10:30 am - 2:30 pm<\/br><\/br>Community Hiring Event:\u00a0Apply to work on the construction of the Prussing Elementary School Annex Friday, January 12, 2018 10:30 am - 2:30 pm at the JEFFERSON PARK BRANCH LIBRARY 5363 WEST LAWRENCE AVENUE CHICAGO, IL 60630 View event flyer. View the Prussing Elementary School Annex project page.",
+        "organiser": 3,
+        "className": [
+            "eo-event-cat-community-hiring",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "category-community-hiring"
+        ],
+        "category": [
+            "community-hiring"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#112e51"
+    },
+    {
+        "title": "Dr. Martin Luther King Jr.\u2019s Birthday",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/dr-martin-luther-king-jr-s-birthday-7\/",
+        "allDay": true,
+        "start": "2018-01-15T00:00:00",
+        "end": "2018-01-16T00:00:00",
+        "description": "January 15, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-past",
+            "eo-all-day",
+            "eo-event",
+            "eo-past-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Bid Opening \u2013 Williams Park Fieldhouse (C1593)",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/bid-opening-williams-park-fieldhouse-c1593\/",
+        "allDay": false,
+        "start": "2018-02-01T11:00:00",
+        "end": "2018-02-01T12:00:00",
+        "description": "February 1, 2018  11:00 am - 12:00 pm<\/br><\/br>Sealed bids will be received at the Public Building Commission, Richard J. Daley Center, 50 West Washington, Room 200, until 11:00 am, Thursday, February 1, 2018, at which time they will be publicly opened. View this event's contract details page. View related project page.",
+        "organiser": 3,
+        "className": [
+            "eo-event-venue-pbc-board-room",
+            "eo-event-cat-opportunity",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "venue-pbc-board-room",
+            "category-opportunity"
+        ],
+        "venue": 110,
+        "venue_slug": "pbc-board-room",
+        "category": [
+            "opportunity"
+        ],
+        "tags": [],
+        "textColor": "#000000",
+        "color": "#f27602"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 February 1, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-february-1-2018\/",
+        "allDay": false,
+        "start": "2018-02-01T13:00:00",
+        "end": "2018-02-01T14:00:00",
+        "description": "February 1, 2018  1:00 pm - 2:00 pm<\/br><\/br>Agenda",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Audit Committee Meeting \u2013 February 1, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/audit-committee-meeting-february-1-2018\/",
+        "allDay": false,
+        "start": "2018-02-01T13:30:00",
+        "end": "2018-02-01T14:30:00",
+        "description": "February 1, 2018  1:30 pm - 2:30 pm<\/br><\/br>Notice Agenda",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-audit-committee",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "category-audit-committee"
+        ],
+        "category": [
+            "audit-committee"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0da3d9"
+    },
+    {
+        "title": "Bid Opening \u2013 Columbia Explorers Elementary School Modular (C1592)",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/bid-opening-columbia-explorers-elementary-school-modular-c1592\/",
+        "allDay": false,
+        "start": "2018-02-06T11:00:00",
+        "end": "2018-02-06T11:30:00",
+        "description": "February 6, 2018  11:00 am - 11:30 am<\/br><\/br>Sealed bids shall be received at the Public Building Commission, Richard J. Daley Center, 50 West Washington, Room 200, until 11:00 a.m. Tuesday, February 6, 2018, at which time they will be publicly opened. View this event's contract details page. View related project page.",
+        "organiser": 5,
+        "className": [
+            "eo-event-venue-daley-plaza",
+            "eo-event-cat-opportunity",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "venue-daley-plaza",
+            "category-opportunity"
+        ],
+        "venue": 111,
+        "venue_slug": "daley-plaza",
+        "category": [
+            "opportunity"
+        ],
+        "tags": [],
+        "textColor": "#000000",
+        "color": "#f27602"
+    },
+    {
+        "title": "Lincoln\u2019s Birthday",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/lincolns-birthday-10\/",
+        "allDay": true,
+        "start": "2018-02-12T00:00:00",
+        "end": "2018-02-13T00:00:00",
+        "description": "February 12, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-past",
+            "eo-all-day",
+            "eo-event",
+            "eo-past-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Board Meeting \u2013 February 13, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-february-13-2018\/",
+        "allDay": false,
+        "start": "2018-02-13T14:30:00",
+        "end": "2018-02-13T15:30:00",
+        "description": "February 13, 2018  2:30 pm - 3:30 pm<\/br><\/br>[vc_row][vc_column][vc_empty_space height=\"16px\"][vc_column_text] Second Floor Board Room Richard J. Daley Center 50 West Washington Street [\/vc_column_text][\/vc_column][\/vc_row][vc_row][vc_column][vc_text_separator title=\"Board Material\"][\/vc_column][\/vc_row][vc_row][vc_column width=\"1\/4\"][vc_btn title=\"Agenda\" style=\"outline-custom\" outline_custom_color=\"#d51f35\" outline_custom_hover_background=\"#d51f35\" outline_custom_hover_text=\"#ffffff\" align=\"center\" link=\"url:http%3A%2F%2Fwww.pbcchicago.com%2Fwp-content%2Fuploads%2F2017%2F12%2FMA_PBC_MPW_posted20180213.pdf|title:Agenda|target:%20_blank|\" button_block=\"true\"][\/vc_column][vc_column width=\"1\/4\"][vc_btn title=\"Presentation\" style=\"outline-custom\" outline_custom_color=\"#d51f35\" outline_custom_hover_background=\"#d51f35\" outline_custom_hover_text=\"#ffffff\" align=\"center\" link=\"url:http%3A%2F%2Fwww.pbcchicago.com%2Fwp-content%2Fuploads%2F2018%2F02%2FBoardPresentation_20180213web.pdf|title:Presentation|target:%20_blank|\" button_block=\"true\"][\/vc_column][vc_column width=\"1\/4\"][vc_btn title=\"Summary\" style=\"outline-custom\" outline_custom_color=\"#d51f35\" outline_custom_hover_background=\"#d51f35\" outline_custom_hover_text=\"#ffffff\" align=\"center\" link=\"url:http%3A%2F%2Fwww.pbcchicago.com%2Fwp-content%2Fuploads%2F2018%2F02%2FBoard-Summary.pdf|title:Summary|target:%20_blank|\" button_block=\"true\"][\/vc_column][vc_column width=\"1\/4\"][vc_btn title=\"Minutes\" style=\"outline\" align=\"center\" link=\"||target:%20_blank|\" button_block=\"true\"][\/vc_column][\/vc_row][vc_row][vc_column][vc_text_separator title=\"Board Actions\"][vc_tta_tabs active_section=\"1\" el_class=\"BoardAction_Tab\"][vc_tta_section title=\"Task...",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-past",
+            "eo-event",
+            "eo-past-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Washington\u2019s Birthday",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/washingtons-birthday-12\/",
+        "allDay": true,
+        "start": "2018-02-19T00:00:00",
+        "end": "2018-02-20T00:00:00",
+        "description": "February 19, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Pre-Bid Meeting \u2013 Chicago Park District Group B (C1595)",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/pre-bid-meeting-chicago-park-district-group-b-c1595\/",
+        "allDay": false,
+        "start": "2018-02-21T09:30:00",
+        "end": "2018-02-21T13:00:00",
+        "description": "February 21, 2018  9:30 am - 1:00 pm<\/br><\/br>On\u00a0Wednesday, February 21, 2018, in the McKinley Park Auditorium, located at 2210 West Pershing Road, Chicago, Illinois 60609, PBC will host a\u00a0Pre-Bid Meeting at 9:30 a.m., a\u00a0Mandatory Technical Review Meeting at 10:00a.m., and a Non-Mandatory Site Visit at 12:00p.m.\u00a0Attendees are to enter through (North) Main Entrance.\u00a0 Parking is available in the parking lot adjacent to...",
+        "organiser": 3,
+        "className": [
+            "eo-event-venue-mckinley-park-auditorium",
+            "eo-event-cat-opportunity",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "venue-mckinley-park-auditorium",
+            "category-opportunity"
+        ],
+        "venue": 117,
+        "venue_slug": "mckinley-park-auditorium",
+        "category": [
+            "opportunity"
+        ],
+        "tags": [],
+        "textColor": "#000000",
+        "color": "#f27602"
+    },
+    {
+        "title": "Site Visit Walk-Through \u2013 Chicago Park District Group B (C1595)",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/site-visit-walk-chicago-park-district-group-b-c1595\/",
+        "allDay": false,
+        "start": "2018-02-22T09:00:00",
+        "end": "2018-02-22T13:30:00",
+        "description": "February 22, 2018  9:00 am - 1:30 pm<\/br><\/br>On\u00a0Thursday, February 22, 2018 at 9:00a.m., Site Visit Walk-throughs for the remaining facilities will commence beginning with the Harrison Park Facility, located at 1824 S. Wood Street, Chicago, Illinois 60608.\u00a0 Attendees are to enter through Main Entrance.\u00a0 Street parking is available but limited.\u00a0 Please arrive early. Following\u00a0at 10:30 a.m. on Thursday, February 22, 2018, is...",
+        "organiser": 3,
+        "className": [
+            "eo-event-venue-harrison-park",
+            "eo-event-cat-opportunity",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "venue-harrison-park",
+            "category-opportunity"
+        ],
+        "venue": 118,
+        "venue_slug": "harrison-park",
+        "category": [
+            "opportunity"
+        ],
+        "tags": [],
+        "textColor": "#000000",
+        "color": "#f27602"
+    },
+    {
+        "title": "Community Hiring Event: Whitney Young Branch Library addition and renovation project",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/community-hiring-event-whitney-young-branch-library-addition-renovation-project\/",
+        "allDay": false,
+        "start": "2018-02-26T12:00:00",
+        "end": "2018-02-26T17:00:00",
+        "description": "February 26, 2018  12:00 pm - 5:00 pm<\/br><\/br>Community Hiring Event:\u00a0 Apply to work on the Whitney Young Branch Library addition &amp; renovation project Monday, February 26, 2018 12:00 pm - 5:00 pm at the CHATHAM BUSINESS ASSOCIATION 800 EAST 78TH STREET CHICAGO, IL 60619 View Event Flyer View the Whitney Young Branch Library addition and renovation\u00a0project page.",
+        "organiser": 5,
+        "className": [
+            "eo-event-cat-community-hiring",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-community-hiring"
+        ],
+        "category": [
+            "community-hiring"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#112e51"
+    },
+    {
+        "title": "Community Hiring Event: Whitney Young Branch Library addition and renovation project",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/community-hiring-event-whitney-young-branch-library-addition-renovation-project-2\/",
+        "allDay": false,
+        "start": "2018-02-27T10:00:00",
+        "end": "2018-02-27T15:00:00",
+        "description": "February 27, 2018  10:00 am - 3:00 pm<\/br><\/br>Community Hiring Event:\u00a0 Apply to work on the Whitney Young Branch Library addition &amp; renovation project Tuesday, February 27, 2018 10:00 am - 3:00 pm at the CHATHAM BUSINESS ASSOCIATION 800 EAST 78TH STREET CHICAGO, IL 60619 View Event Flyer View the Whitney Young Branch Library addition and renovation\u00a0project page.",
+        "organiser": 5,
+        "className": [
+            "eo-event-cat-community-hiring",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-community-hiring"
+        ],
+        "category": [
+            "community-hiring"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#112e51"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 March 1, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-march-1-2018\/",
+        "allDay": false,
+        "start": "2018-03-01T13:00:00",
+        "end": "2018-03-01T14:00:00",
+        "description": "March 1, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Pulaski Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/pulaski-day-11\/",
+        "allDay": true,
+        "start": "2018-03-05T00:00:00",
+        "end": "2018-03-06T00:00:00",
+        "description": "March 5, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Bid Opening Chicago Park District Group A  (C1594)",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/bid-opening-chicago-park-district-group-a-c1594\/",
+        "allDay": false,
+        "start": "2018-03-07T11:00:00",
+        "end": "2018-03-07T12:00:00",
+        "description": "March 7, 2018  11:00 am - 12:00 pm<\/br><\/br>",
+        "organiser": 5,
+        "className": [
+            "eo-event-venue-daley-plaza",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "venue-daley-plaza"
+        ],
+        "venue": 111,
+        "venue_slug": "daley-plaza",
+        "category": [],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#A34F16"
+    },
+    {
+        "title": "Board Meeting \u2013 March 13, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-march-13-2018\/",
+        "allDay": false,
+        "start": "2018-03-13T14:30:00",
+        "end": "2018-03-13T15:30:00",
+        "description": "March 13, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Bid Opening \u2013 Chicago Park District Group B",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/bid-opening-chicago-park-district-group-b\/",
+        "allDay": false,
+        "start": "2018-03-20T11:00:00",
+        "end": "2018-03-20T12:00:00",
+        "description": "March 20, 2018  11:00 am - 12:00 pm<\/br><\/br>Details here.",
+        "organiser": 3,
+        "className": [
+            "eo-event-venue-pbc-board-room",
+            "eo-event-cat-opportunity",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "venue-pbc-board-room",
+            "category-opportunity"
+        ],
+        "venue": 110,
+        "venue_slug": "pbc-board-room",
+        "category": [
+            "opportunity"
+        ],
+        "tags": [],
+        "textColor": "#000000",
+        "color": "#f27602"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 March 29, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-march-29-2018\/",
+        "allDay": false,
+        "start": "2018-03-29T13:00:00",
+        "end": "2018-03-29T14:00:00",
+        "description": "March 29, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Board Meeting \u2013 April 10, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-april-10-2018\/",
+        "allDay": false,
+        "start": "2018-04-10T14:30:00",
+        "end": "2018-04-10T15:30:00",
+        "description": "April 10, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 April 26, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-april-26-2018\/",
+        "allDay": false,
+        "start": "2018-04-26T13:00:00",
+        "end": "2018-04-26T14:00:00",
+        "description": "April 26, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Board Meeting \u2013 May 8, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-may-8-2018\/",
+        "allDay": false,
+        "start": "2018-05-08T14:30:00",
+        "end": "2018-05-08T15:30:00",
+        "description": "May 8, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Memorial Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/memorial-day-13\/",
+        "allDay": true,
+        "start": "2018-05-28T00:00:00",
+        "end": "2018-05-29T00:00:00",
+        "description": "May 28, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 May 31, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-may-31-2018\/",
+        "allDay": false,
+        "start": "2018-05-31T13:00:00",
+        "end": "2018-05-31T14:00:00",
+        "description": "May 31, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Board Meeting \u2013 June 12, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-june-12-2018\/",
+        "allDay": false,
+        "start": "2018-06-12T14:30:00",
+        "end": "2018-06-12T15:30:00",
+        "description": "June 12, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 June 28, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-june-28-2018\/",
+        "allDay": false,
+        "start": "2018-06-28T13:00:00",
+        "end": "2018-06-28T14:00:00",
+        "description": "June 28, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Independence Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/independence-day-14\/",
+        "allDay": true,
+        "start": "2018-07-04T00:00:00",
+        "end": "2018-07-05T00:00:00",
+        "description": "July 4, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Board Meeting \u2013 July 10, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-july-10-2018\/",
+        "allDay": false,
+        "start": "2018-07-10T14:30:00",
+        "end": "2018-07-10T15:30:00",
+        "description": "July 10, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 August 2, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-august-2-2018\/",
+        "allDay": false,
+        "start": "2018-08-02T13:00:00",
+        "end": "2018-08-02T14:00:00",
+        "description": "August 2, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Board Meeting \u2013 August 14, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-august-14-2018\/",
+        "allDay": false,
+        "start": "2018-08-14T14:30:00",
+        "end": "2018-08-14T15:30:00",
+        "description": "August 14, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 August 30, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-august-30-2018\/",
+        "allDay": false,
+        "start": "2018-08-30T13:00:00",
+        "end": "2018-08-30T14:00:00",
+        "description": "August 30, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Labor Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/labor-day-14\/",
+        "allDay": true,
+        "start": "2018-09-03T00:00:00",
+        "end": "2018-09-04T00:00:00",
+        "description": "September 3, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Board Meeting \u2013 September 11, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-september-11-2018\/",
+        "allDay": false,
+        "start": "2018-09-11T14:30:00",
+        "end": "2018-09-11T15:30:00",
+        "description": "September 11, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 September 20, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-september-20-2018\/",
+        "allDay": false,
+        "start": "2018-09-20T13:00:00",
+        "end": "2018-09-20T14:00:00",
+        "description": "September 20, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Board Meeting \u2013 October 1, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-october-1-2018\/",
+        "allDay": false,
+        "start": "2018-10-01T14:30:00",
+        "end": "2018-10-01T15:30:00",
+        "description": "October 1, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Columbus Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/columbus-day-13\/",
+        "allDay": true,
+        "start": "2018-10-08T00:00:00",
+        "end": "2018-10-09T00:00:00",
+        "description": "October 8, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 November 1, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-november-1-2018\/",
+        "allDay": false,
+        "start": "2018-11-01T13:00:00",
+        "end": "2018-11-01T14:00:00",
+        "description": "November 1, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Veteran\u2019s Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/veterans-day-13\/",
+        "allDay": true,
+        "start": "2018-11-12T00:00:00",
+        "end": "2018-11-13T00:00:00",
+        "description": "November 12, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Board Meeting \u2013 November 13, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-november-13-2018\/",
+        "allDay": false,
+        "start": "2018-11-13T14:30:00",
+        "end": "2018-11-13T15:30:00",
+        "description": "November 13, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Thanksgiving Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/thanksgiving-day-9\/",
+        "allDay": true,
+        "start": "2018-11-22T00:00:00",
+        "end": "2018-11-23T00:00:00",
+        "description": "November 22, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    },
+    {
+        "title": "Administrative Operations Committee Meeting \u2013 November 29, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/administrative-operations-committee-meeting-november-29-2018\/",
+        "allDay": false,
+        "start": "2018-11-29T13:00:00",
+        "end": "2018-11-29T14:00:00",
+        "description": "November 29, 2018  1:00 pm - 2:00 pm<\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-admin-opp-committee-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-admin-opp-committee-meeting"
+        ],
+        "category": [
+            "admin-opp-committee-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#0fa92a"
+    },
+    {
+        "title": "Board Meeting \u2013 December 11, 2018",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/board-meeting-december-11-2018\/",
+        "allDay": false,
+        "start": "2018-12-11T14:30:00",
+        "end": "2018-12-11T15:30:00",
+        "description": "December 11, 2018  2:30 pm - 3:30 pm<\/br><\/br>Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-board-meeting",
+            "eo-event-future",
+            "eo-event",
+            "eo-future-event",
+            "category-board-meeting"
+        ],
+        "category": [
+            "board-meeting"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#d51f35"
+    },
+    {
+        "title": "Christmas Day",
+        "url": "http:\/\/www.pbcchicago.com\/events\/event\/christmas-day-8\/",
+        "allDay": true,
+        "start": "2018-12-25T00:00:00",
+        "end": "2018-12-26T00:00:00",
+        "description": "December 25, 2018 <\/br><\/br>",
+        "organiser": 9,
+        "className": [
+            "eo-event-cat-holiday",
+            "eo-event-future",
+            "eo-all-day",
+            "eo-event",
+            "eo-future-event",
+            "category-holiday"
+        ],
+        "category": [
+            "holiday"
+        ],
+        "tags": [],
+        "textColor": "#ffffff",
+        "color": "#4d4f53"
+    }
+]

--- a/tests/test_chi_buildings.py
+++ b/tests/test_chi_buildings.py
@@ -1,86 +1,84 @@
 import pytest
+import scrapy
 
 from datetime import datetime
 from tests.utils import file_response
 from documenters_aggregator.spiders.chi_buildings import Chi_buildingsSpider
 
 
-test_response = file_response('files/chi_buildings.html')
+test_json_response = file_response('files/chi_buildings.json')
+test_event_response = file_response('files/chi_buildings.html')
 spider = Chi_buildingsSpider()
 # Setting spider date to time test files were generated
-spider.calendar_date = datetime(2017, 10, 15)
-parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
+spider.calendar_date = datetime(2018, 2, 18)
+
+
+class MockRequest(object):
+    meta = {}
+
+    def __getitem__(self, key):
+        return self.meta['item'].get(key)
+
+
+def mock_request(*args, **kwargs):
+    mock = MockRequest()
+    mock.meta = {'item': {}}
+    return mock
+
+
+setattr(scrapy, 'Request', mock_request)
+parsed_items = [item for item in spider.parse(test_json_response)]
+parsed_event = spider._parse_event(test_event_response)
 
 
 def test_name():
-    assert parsed_items[0]['name'] == 'Daley Plaza - Italian Exhibit'
-
-
-def test_afb_name():
-    assert parsed_items[3]['name'] == 'Advertisement for Bids - Ebinger Elementary School Annex'
-
-
-def test_description():
-    assert parsed_items[0]['description'] is None
-
-
-def test_afb_description():
-    assert parsed_items[3]['description'] == 'Details on advertisement for bids at: http://www.pbcchicago.com/content/working/opening_display.asp?BID_ID=503'
-
-
-def test_start_time():
-    assert parsed_items[0]['start_time'] == '2017-10-16T00:00:00-05:00'
-
-
-def test_start_time_with_hours():
-    assert parsed_items[3]['start_time'] == '2017-10-18T10:00:00-05:00'
+    assert parsed_items[0]['name'] == 'Administrative Operations Committee Meeting – January 4, 2018'
 
 
 @pytest.mark.parametrize('item', parsed_items)
-def test_end_time(item):
-    assert item['end_time'] is None
-
-
-def test_id():
-    assert parsed_items[0]['id'] == 'chi_buildings/201710160000/2176/daley_plaza_italian_exhibit'
-
-
-def test_all_day():
-    assert parsed_items[0]['all_day'] is True
-
-
-def test_non_all_day():
-    assert parsed_items[3]['all_day'] is False
+def test_no_holidays_included(item):
+    assert item['classification'] != 'Holiday'
 
 
 def test_classification():
-    assert parsed_items[0]['classification'] == 'Daley Plaza'
-
-
-def test_afb_classification():
-    assert parsed_items[3]['classification'] == 'Advertisement for Bids'
+    assert parsed_items[0]['classification'] == 'Admin Opp Committee Meeting'
+    assert parsed_items[1]['classification'] == 'Community Hiring'
+    assert parsed_items[2]['classification'] == 'Board Meeting'
+    assert parsed_items[3]['classification'] == 'Opportunity'
 
 
 @pytest.mark.parametrize('item', parsed_items)
-def test_status(item):
-    assert item['status'] == 'tentative'
+def test_description(item):
+    assert item['description'] is None
 
 
-def test_location():
-    assert parsed_items[0]['location'] == {
-        'url': None,
-        'name': None,
-        'coordinates': {
-            'latitude': None,
-            'longitude': None,
-        },
-    }
+def test_start_time():
+    assert parsed_items[0]['start_time'] == '2018-01-04T13:00:00-06:00'
+
+
+def test_end_time():
+    assert parsed_items[0]['end_time'] == '2018-01-04T14:00:00-06:00'
+
+
+def test_id():
+    assert parsed_items[0]['id'] == 'chi_buildings/201801041300/x/administrative_operations_committee_meeting_january_4_2018'
+
+
+@pytest.mark.parametrize('item', parsed_items)
+def test_all_day(item):
+    assert item['all_day'] is False
+
+
+def test_status():
+    assert parsed_items[0]['status'] == 'passed'
+    assert parsed_items[10]['status'] == 'tentative'
 
 
 def test_board_meeting_location():
-    assert parsed_items[9]['location'] == {
+    assert parsed_items[0]['location'] == {
         'url': 'https://thedaleycenter.com',
-        'name': 'Second Floor Board Room, Richard J. Daley Center, 50 W. Washington Street',
+        'name': 'Second Floor Board Room, Richard J. Daley Center',
+        'address': '50 W. Washington Street Chicago, IL 60602',
         'coordinates': {
             'latitude': '41.884089',
             'longitude': '-87.630191',
@@ -94,9 +92,34 @@ def test__type(item):
 
 
 def test_source():
-    assert parsed_items[0]['sources'][0]['url'] == 'http://www.pbcchicago.com/content/about/calendar_detail.asp?eID=2176'
+    assert parsed_items[0]['sources'][0]['url'] == (
+        'http://www.pbcchicago.com/events/event/administrative-operations-committee-meeting-january-4-2018/'
+    )
 
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_timezone(item):
     assert item['timezone'] == 'America/Chicago'
+
+
+def test_event_description():
+    assert parsed_event['description'] == (
+        'On Wednesday, February 21, 2018, in the McKinley Park Auditorium, located at '
+        '2210 West Pershing Road, Chicago, Illinois 60609, PBC will host a Pre-Bid Meeting '
+        'at 9:30 a.m., a Mandatory Technical Review Meeting at 10:00a.m., and a Non-Mandatory '
+        'Site Visit at 12:00p.m. Attendees are to enter through (North) Main Entrance. Parking '
+        'is available in the parking lot adjacent to the McKinley Park Fieldhouse. Details here: '
+        'http://www.pbcchicago.com/opportunities/chicago-park-district-group-b-c1595/'
+    )
+
+
+def test_event_location():
+    assert parsed_event['location'] == {
+        'url': None,
+        'name': 'McKinley Park Auditorium',
+        'address': '2210 West Pershing Road, Chicago, IL, 60609, USA',
+        'coordinates': {
+            'latitude': '41.823738',
+            'longitude': '-87.682445',
+        },
+    }


### PR DESCRIPTION
Closes #252. A more detailed description and location information aren't included in the JSON endpoint, so the spider scrapes those pages if they aren't board meetings (which generally don't have any more info)