### PR TITLE
Create icon dashboard for scraper status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,8 @@ src/
 deploy/*.sh
 deploy/*.py
 
+!deploy/scrapers_status.py
+
 # OS files
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,32 @@ A. We have ongoing conversations about what sort of data we should collect and h
 
 B. Research sources for public meetings. Answer questions like: Are we scraping events from the right websites? Are there local agencies that we're missing? Should events be updated manually or by a scraper? [Triage events sources on these issues](https://github.com/City-Bureau/city-scrapers/issues?q=is%3Aissue+is%3Aopen+label%3A%22non-coding%3A+triage+events+source%22).
 
+## Scraper Status
+
+| Scraper | Status |
+|---------|--------|
+| Chicago Animal Care and Control Commission | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_animal.svg) |
+| Public Building Commission of Chicago | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_buildings.svg) |
+| City College of Chicago | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_city_college.svg) |
+| Chicago Infrastructure Trust | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_infra.svg) |
+| Chicago Parks District | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_parks.svg) |
+| Chicago Police Department | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_police.svg) |
+| Chicago Police Board | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_policeboard.svg) |
+| Chicago Department of Public Health | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_pubhealth.svg) |
+| Chicago Public Schools: School Actions | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_school_actions.svg) |
+| Chicago Public Schools Board of Education | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_schools.svg) |
+| Chicago Transit Authority | ![Status](https://s3.amazonaws.com/city-scrapers-status/chi_transit.svg) |
+| Cook County Board of Commissioners | ![Status](https://s3.amazonaws.com/city-scrapers-status/cook_board.svg) |
+| Cook County Government | ![Status](https://s3.amazonaws.com/city-scrapers-status/cook_county.svg) |
+| Cook County Electoral Board | ![Status](https://s3.amazonaws.com/city-scrapers-status/cook_electoral.svg) |
+| Cook County Health and Hospitals System | ![Status](https://s3.amazonaws.com/city-scrapers-status/cook_hospitals.svg) |
+| Cook County Land Bank | ![Status](https://s3.amazonaws.com/city-scrapers-status/cook_landbank.svg) |
+| Cook County Department of Public Health | ![Status](https://s3.amazonaws.com/city-scrapers-status/cook_pubhealth.svg) |
+| Illinois Labor Relations Board | ![Status](https://s3.amazonaws.com/city-scrapers-status/il_labor.svg) |
+| Metra Board of Directors | ![Status](https://s3.amazonaws.com/city-scrapers-status/metra_board.svg) |
+| Regional Transportation Authority | ![Status](https://s3.amazonaws.com/city-scrapers-status/regionaltransit.svg) |
+| Ward Nights | ![Status](https://s3.amazonaws.com/city-scrapers-status/ward_night.svg) |
+
 ## Support this work
 
 This project is organized and maintained by [City Bureau](http://www.citybureau.org/) and [ProPublica Illinois](https://www.propublica.org/illinois).

--- a/deploy/scrapers_status.py
+++ b/deploy/scrapers_status.py
@@ -2,6 +2,7 @@ import os
 import boto3
 from datetime import datetime
 
+PROJECT_SLUG = 'documenters_aggregator'
 STATUS_BUCKET = os.getenv('STATUS_BUCKET')
 
 STATUS_COLOR_MAP = {
@@ -48,8 +49,10 @@ def handler(event, context):
         status = 'failed'
     else:
         status = 'running'
-    # TODO: Find where to pull scraper name from
-    scraper = event['TBD']
+
+    # Pull scraper name from ARN in documenters_aggregator-{SCRAPER}
+    task_def = event['detail']['taskDefinitionArn'].split('/')[0]
+    scraper = task_def.split(':')[-1][len(PROJECT_SLUG) + 1:]
 
     client.put_object(
         Bucket=STATUS_BUCKET,

--- a/deploy/scrapers_status.py
+++ b/deploy/scrapers_status.py
@@ -1,0 +1,51 @@
+import os
+import boto3
+from datetime import datetime
+
+STATUS_BUCKET = os.getenv('STATUS_BUCKET')
+
+STATUS_COLOR_MAP = {
+    'running': '#4c1',
+    'failing': '#cb2431',
+    'unclear': '#dfb317'
+}
+
+STATUS_ICON = '''
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="144" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="a">
+        <rect width="144" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#a)">
+        <path fill="#555" d="M0 0h67v20H0z"/>
+        <path fill="{color}" d="M67 0h77v20H67z"/>
+        <path fill="url(#b)" d="M0 0h144v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+        <text x="345" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">{status}</text>
+        <text x="345" y="140" transform="scale(.1)">{status}</text>
+        <text x="1045" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">{date}</text>
+        <text x="1045" y="140" transform="scale(.1)">{date}</text>
+    </g>
+</svg>
+'''
+
+
+def handler(event, context):
+    client = boto3.client('s3')
+    # TODO: Figure out where to pull values from
+    scraper = event['TBD']
+    status = event['TBD']
+
+    client.put_object(
+        Bucket=STATUS_BUCKET,
+        Key='{}.svg'.format(scraper),
+        Body=STATUS_ICON.format(
+            color=STATUS_COLOR_MAP.get(status, '#dfb317'),
+            status=status,
+            date=datetime.today().strftime('%Y-%m-%d')
+        )
+    )

--- a/deploy/scrapers_status.py
+++ b/deploy/scrapers_status.py
@@ -36,9 +36,20 @@ STATUS_ICON = '''
 
 def handler(event, context):
     client = boto3.client('s3')
-    # TODO: Figure out where to pull values from
+
+    if 'detail-type' not in event or event['detail-type'] != 'ECS Task State Change':
+        raise ValueError('ERROR: Event is not an ECS task state change event')
+
+    if event['detail']['lastStatus'] != 'STOPPED':
+        print('INFO: Last status was not STOPPED, exiting...')
+        return
+
+    if event['detail']['stoppedReason'] == 'Essential container in task exited':
+        status = 'failed'
+    else:
+        status = 'running'
+    # TODO: Find where to pull scraper name from
     scraper = event['TBD']
-    status = event['TBD']
 
     client.put_object(
         Bucket=STATUS_BUCKET,

--- a/deploy/scrapers_status_cfn.yml
+++ b/deploy/scrapers_status_cfn.yml
@@ -1,0 +1,91 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  StatusBucketName:
+    Type: String
+    Default: city-scrapers-status
+    Description: Name of S3 Bucket to be created
+  CodeBucketName:
+    Type: String
+    Default: city-scrapers-lambda
+    Description: Name of S3 Bucket containing the key in LambdaFileKey
+  LambdaFileKey:
+    Type: String
+    Default: scrapers_status.zip
+    Description: Zip file key name containing the application code
+  LambdaHandler:
+    Type: String
+    Default: scrapers_status.handler
+    Description: The Python file name and handler function inside the zip file
+Resources:
+  ScraperStatusBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref StatusBucketName
+      AccessControl: PublicRead
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: unavailable.svg
+  ScraperStatusBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DependsOn: ScraperStatusBucket
+    Properties:
+      Bucket: !Ref StatusBucketName
+      PolicyDocument:
+        Statement:
+        - Sid: AllowPublicRead
+          Effect: Allow
+          Principal:
+            AWS: "*"
+          Action: s3:GetObject
+          Resource:
+            Fn::Sub:
+            - arn:aws:s3:::${Bucket}/*
+            - { Bucket: !Ref StatusBucketName }
+  IamRoleLambdaExecution:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Policies:
+      - PolicyName: scraper-lambda-execution-role
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:*
+            Resource:
+            - arn:aws:logs:*:*:*
+          - Effect: Allow
+            Action: s3:*
+            Resource:
+              Fn::Sub:
+              - arn:aws:s3:::${Bucket}/*
+              - { Bucket: !Ref StatusBucketName }
+  ScraperStatusLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref CodeBucketName
+        S3Key: !Ref LambdaFileKey
+      FunctionName: city-scrapers-status
+      Handler: !Ref LambdaHandler
+      MemorySize: 1024
+      Role:
+        Fn::GetAtt:
+        - IamRoleLambdaExecution
+        - Arn
+      Runtime: python3.6
+      Timeout: 300
+      Environment:
+        Variables:
+          STATUS_BUCKET: !Ref StatusBucketName
+    DependsOn: IamRoleLambdaExecution
+      


### PR DESCRIPTION
Working on #265. Adds a CloudFormation template that creates the Lambda function and S3 bucket to store icons for each scraper's status. I tested it on my AWS account, and everything runs as expected from a test event (when the event-specific parts are commented out). We should be able to add a trigger from an ECS task state change to get it running, but I'm not sure where in the event object I can pull the scraper name

@jim let me know what you think, and if you have a sense of where we can get the scraper info