### PR TITLE
Add no-cache to SVG icon headers

### DIFF
--- a/deploy/scrapers_status.py
+++ b/deploy/scrapers_status.py
@@ -67,5 +67,6 @@ def handler(event, context):
             status=status,
             date=datetime.today().strftime('%Y-%m-%d')
         ),
+        CacheControl='no-cache',
         ContentType='image/svg+xml',
     )


### PR DESCRIPTION
Should fix some issues with #265. Sets 'Cache-Control' header for the SVGs on S3