### PR TITLE
updates doc links in  code and template to point to GH pages

### DIFF
--- a/docs/03_contribute.md
+++ b/docs/03_contribute.md
@@ -125,7 +125,7 @@ class Chi_housingSpider(scrapy.Spider):
     def parse(self, response):
         """
         `parse` should always `yield` a dict that follows the Event Schema
-        <https://city-bureau.gitbooks.io/documenters-event-aggregator/event-schema.html>.
+        <https://city-bureau.github.io/city-scrapers/06_event_schema.html>.
 
         Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
         needs.

--- a/documenters_aggregator/settings.py
+++ b/documenters_aggregator/settings.py
@@ -15,7 +15,7 @@ SPIDER_MODULES = ['documenters_aggregator.spiders']
 NEWSPIDER_MODULE = 'documenters_aggregator.spiders'
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-USER_AGENT = 'Documenters Aggregator [development mode]. Learn more and say hello at https://city-bureau.gitbooks.io/documenters-event-aggregator/'
+USER_AGENT = 'Documenters Aggregator [development mode]. Learn more and say hello at https://city-bureau.github.io/city-scrapers/'
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = False

--- a/documenters_aggregator/spiders/chi_school_actions.py
+++ b/documenters_aggregator/spiders/chi_school_actions.py
@@ -13,7 +13,7 @@ class ChiSchoolActionsSpider(Spider):
     def parse(self, response):
         """
         `parse` should always `yield` a dict that follows the Event Schema
-        <https://city-bureau.gitbooks.io/documenters-event-aggregator/event-schema.html>.
+        <https://city-bureau.github.io/city-scrapers/06_event_schema.html>.
 
         Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
         needs.

--- a/documenters_aggregator/spiders/metra_board.py
+++ b/documenters_aggregator/spiders/metra_board.py
@@ -14,7 +14,7 @@ class Metra_boardSpider(Spider):
     def parse(self, response):
         """
         `parse` should always `yield` a dict that follows the Event Schema
-        <https://city-bureau.gitbooks.io/documenters-event-aggregator/event-schema.html>.
+        <https://city-bureau.github.io/city-scrapers/06_event_schema.html>.
 
         Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
         needs.

--- a/templates/spider.tmpl
+++ b/templates/spider.tmpl
@@ -12,7 +12,7 @@ class {{ classname }}(Spider):
     def parse(self, response):
         """
         `parse` should always `yield` a dict that follows the Event Schema
-        <https://city-bureau.gitbooks.io/documenters-event-aggregator/event-schema.html>.
+        <https://city-bureau.github.io/city-scrapers/06_event_schema.html>.
 
         Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
         needs.

--- a/tests/files/testspider.py.example
+++ b/tests/files/testspider.py.example
@@ -12,7 +12,7 @@ class TestspiderSpider(Spider):
     def parse(self, response):
         """
         `parse` should always `yield` a dict that follows the Event Schema
-        <https://city-bureau.gitbooks.io/documenters-event-aggregator/event-schema.html>.
+        <https://city-bureau.github.io/city-scrapers/06_event_schema.html>.
 
         Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
         needs.

--- a/travis/travis_settings.py
+++ b/travis/travis_settings.py
@@ -15,7 +15,7 @@ SPIDER_MODULES = ['documenters_aggregator.spiders']
 NEWSPIDER_MODULE = 'documenters_aggregator.spiders'
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
-USER_AGENT = 'Documenters Aggregator [development mode]. Learn more and say hello at https://city-bureau.gitbooks.io/documenters-event-aggregator/'
+USER_AGENT = 'Documenters Aggregator [development mode]. Learn more and say hello at https://city-bureau.github.io/city-scrapers/'
 
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = False


### PR DESCRIPTION
I noticed the spider template was pointing to the gitbooks version of the docs, which appear to be broken. It looks like we switched to GH pages for docs, so I updated all the URLS to be current. 