### PR TITLE
Use usaddress to make conservative guess at address

### DIFF
--- a/documenters_aggregator/spiders/il_pubhealth.py
+++ b/documenters_aggregator/spiders/il_pubhealth.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 import scrapy
 import usaddress
 from dateutil.parser import parse as dateparse
@@ -12,6 +13,7 @@ class Il_pubhealthSpider(Spider):
     allowed_domains = ['www.dph.illinois.gov']
     start_urls = ['http://www.dph.illinois.gov/events']
     domain_root = 'http://www.dph.illinois.gov'
+    chicago_matcher_regex = re.compile('Chicago')
 
     def parse(self, response):
         """
@@ -74,12 +76,13 @@ class Il_pubhealthSpider(Spider):
         lines = item.css('div.event_description p::text').extract()
         lines = [line.strip() for line in lines]
 
-        for line in lines:
-            address = self._find_possible_address(line)
-            if address:
-                break
-        else:
-            address = ''
+        address = self._find_high_confidence_address(lines)
+        if address is None:
+            address = self._find_medium_confidence_address(lines)
+        if address is None:
+            address = self._find_low_confidence_address(lines)
+        if address is None:
+            address = 'multiple locations not in Chicago, see description'
 
         return {
             'url': '',
@@ -88,13 +91,30 @@ class Il_pubhealthSpider(Spider):
             'coordinates': {'longitude': '', 'latitude': ''},
         }
 
-    def _find_possible_address(self, line):
-        try:
-            tagged_address, address_type = usaddress.tag(line)
-            if address_type  == "Street Address" and tagged_address.get("PlaceName") == "Chicago":
+    def _find_high_confidence_address(self, lines):
+        for line in lines:
+            try:
+                tagged_address, address_type = usaddress.tag(line)
+                if address_type  == "Street Address" and tagged_address.get("PlaceName") == "Chicago":
+                    return line
+            except usaddress.RepeatedLabelError:
+                pass
+        else:
+            return None
+
+    def _find_medium_confidence_address(self, lines):
+        for line in lines:
+            parsed_address = usaddress.parse(line)
+            for address_component in parsed_address:
+                if address_component[1]  == "PlaceName" and address_component[0] == "Chicago":
+                    return line
+        else:
+            return None
+
+    def _find_low_confidence_address(self, lines):
+        for line in lines:
+            if self.chicago_matcher_regex.search(line):
                 return line
-        except usaddress.RepeatedLabelError:
-            pass
         else:
             return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ traitlets==4.3.2
 Twisted==17.5.0
 Unidecode==0.4.21
 urllib3==1.22
+usaddress==0.5.10
 validictory==1.1.1
 w3lib==1.17.0
 wcwidth==0.1.7

--- a/tests/test_il_pubhealth.py
+++ b/tests/test_il_pubhealth.py
@@ -50,11 +50,44 @@ def test_status(item):
     assert item['status'] == 'tentative'
 
 
-def test_location():
-    assert parsed_items[2]['location'] == {
+def test_high_confidence_location():
+    addr_lines = [
+        'Top of the Building',
+        '69 West Washington St., 35th Floor, Chicago',
+        '-OR-',
+        '500 Vernon, Normal, IL 61761'
+    ]
+    address = spider._find_high_confidence_address(addr_lines)
+
+    assert address == '69 West Washington St., 35th Floor, Chicago'
+
+def test_medium_confidence_location():
+    addr_lines = [
+        'Top of the Building',
+        '122 S. Michigan Avenue, Room 711, West Chicago',
+        '-OR-',
+        '500 Vernon, Normal, IL 61761'
+    ]
+    address = spider._find_medium_confidence_address(addr_lines)
+
+    assert address == '122 S. Michigan Avenue, Room 711, West Chicago'
+
+def test_low_confidence_location():
+    addr_lines = [
+        'Top of the Building',
+        '1234 Main St, West Side, 57th Floor, Chicago, IL',
+        '-OR-',
+        '500 Vernon, Normal, IL 61761'
+    ]
+    address = spider._find_low_confidence_address(addr_lines)
+
+    assert address == '1234 Main St, West Side, 57th Floor, Chicago, IL'
+
+def test_no_matching_location():
+    assert parsed_items[8]['location'] == {
         'url': '',
         'name': '',
-        'address': '69 West Washington St., 35th Floor, Chicago',
+        'address': 'multiple locations not in Chicago, see description',
         'coordinates': {'latitude': '', 'longitude': ''}
     }
 

--- a/tests/test_il_pubhealth.py
+++ b/tests/test_il_pubhealth.py
@@ -9,7 +9,6 @@ test_response = file_response('files/il_pubhealth.html', url='http://www.dph.ill
 spider = Il_pubhealthSpider()
 parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
 
-
 def test_name():
     assert parsed_items[2]['name'] == 'PAC: Maternal Mortality Review Committee Meeting'
 
@@ -51,12 +50,11 @@ def test_status(item):
     assert item['status'] == 'tentative'
 
 
-@pytest.mark.parametrize('item', parsed_items)
-def test_location(item):
-    assert item['location'] == {
+def test_location():
+    assert parsed_items[2]['location'] == {
         'url': '',
         'name': '',
-        'address': '',
+        'address': '69 West Washington St., 35th Floor, Chicago',
         'coordinates': {'latitude': '', 'longitude': ''}
     }
 


### PR DESCRIPTION
This change uses the [usaddress](https://github.com/datamade/usaddress) to make a conservative guess at the correct address in the free form description.

This is a first pass fix for https://github.com/City-Bureau/city-scrapers/issues/201.