### PR TITLE
Ignore test HTML in GitHub repo language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests/files/* linguist-generated
+tests/cassettes/* linguist-generated


### PR DESCRIPTION
This is a really minor, superficial thing so feel free to ignore it, but it's been bugging me that the repo shows up as HTML on GitHub even though the actual code is Python. This adds a `.gitattributes` file to ignore all of the test HTML files in the language stats by [treating them as generated code](https://github.com/github/linguist#generated-code). It doesn't show up as fixed when you view my branch because it looks like the calculations are based on the main/master branch https://help.github.com/articles/about-repository-languages/