### PR TITLE
Issue 310 - fix typo in spider.tmpl

### DIFF
--- a/templates/spider.tmpl
+++ b/templates/spider.tmpl
@@ -68,7 +68,7 @@ class {{ classname }}(Spider):
 
     def _parse_description(self, item):
         """
-        Parse or generate event name.
+        Parse or generate event description.
         """
         return ''
 

--- a/tests/files/testspider.py.example
+++ b/tests/files/testspider.py.example
@@ -68,7 +68,7 @@ class TestspiderSpider(Spider):
 
     def _parse_description(self, item):
         """
-        Parse or generate event name.
+        Parse or generate event description.
         """
         return ''
 


### PR DESCRIPTION
Addresses issue #310, fix typo in spider.tmpl, add a new line at end of doc.