### PR TITLE
Add S3 JSONLines feed export

### DIFF
--- a/city_scrapers/exporters.py
+++ b/city_scrapers/exporters.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from pytz import timezone
+from scrapy.exporters import JsonLinesItemExporter
+
+
+class CityScrapersJsonLinesItemExporter(JsonLinesItemExporter):
+    def serialize_field(self, field, name, value):
+        if isinstance(value, datetime):
+            return value.strftime('%Y-%m-%dT%H:%M:%S')
+        return super(CityScrapersJsonLinesItemExporter, self).serialize_field(field, name, value)

--- a/city_scrapers/pipelines/__init__.py
+++ b/city_scrapers/pipelines/__init__.py
@@ -5,6 +5,7 @@ from .sqlalchemy import CityScrapersSQLAlchemyPipeline
 from .ValidationPipeline import ValidationPipeline
 from .TravisValidation import TravisValidationPipeline
 from .localExporter import CsvPipeline
+from .item import CityScrapersItemPipeline
 
 
 __all__ = (
@@ -14,5 +15,6 @@ __all__ = (
     'CityScrapersSQLAlchemyPipeline',
     'ValidationPipeline',
     'TravisValidationPipeline',
-    'CsvPipeline'
+    'CsvPipeline',
+    'CityScrapersItemPipeline'
 )

--- a/city_scrapers/pipelines/airtable.py
+++ b/city_scrapers/pipelines/airtable.py
@@ -52,7 +52,6 @@ class AirtablePipeline(object):
         new_item['location_address'] = get_key(new_item, 'location.address')
         new_item['location_latitude'] = get_key(new_item, 'location.coordinates.latitude')
         new_item['location_longitude'] = get_key(new_item, 'location.coordinates.longitude')
-        new_item['agency_name'] = spider.long_name
         new_item['url'] = new_item.get('sources', [{'url': ''}])[0].get('url', '')
 
         new_item = {k: self._format_values(k, v) for k, v in new_item.items() if k in KEEP_FIELDS}

--- a/city_scrapers/pipelines/item.py
+++ b/city_scrapers/pipelines/item.py
@@ -1,0 +1,8 @@
+class CityScrapersItemPipeline(object):
+    """
+    Pipeline for doing any custom processing on individual
+    items, i.e. assigning the long name to agency_name
+    """
+    def process_item(self, item, spider):
+        item['agency_name'] = spider.long_name
+        return item

--- a/deploy/prod_settings.py
+++ b/deploy/prod_settings.py
@@ -37,6 +37,7 @@ COOKIES_ENABLED = False
 ITEM_PIPELINES = {
     # disabled until we can rebuild it on another provider
     #'city_scrapers.pipelines.GeocoderPipeline': 200,
+    'city_scrapers.pipelines.CityScrapersItemPipeline': 200,
     'city_scrapers.pipelines.ValidationPipeline': 300,
     'city_scrapers.pipelines.AirtablePipeline': 400
 }

--- a/deploy/prod_settings.py
+++ b/deploy/prod_settings.py
@@ -104,3 +104,11 @@ EXTENSIONS = {
 #HTTPCACHE_DIR = 'httpcache'
 #HTTPCACHE_IGNORE_HTTP_CODES = []
 #HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+
+# Write spiders to S3 bucket
+FEED_EXPORTERS = {
+    'cityscrapers_jsonlines': 'city_scrapers.exporters.CityScrapersJsonLinesItemExporter'
+}
+
+FEED_FORMAT = 'cityscrapers_jsonlines'
+FEED_URI = 's3://city-scrapers-events-feed/%(name)s/%(time)s.json'


### PR DESCRIPTION
Adds an initial feed export for writing newline-delimited JSON to S3 for each scraper after it's run in production. We'll likely have a different setup for writing files to S3 for the actual platform, but this is a decent placeholder for running the [public events viewer](https://github.com/City-Bureau/city-scrapers-events)

Also closes #333 by adding a new `CityScrapersItemPipeline` that splits out the `agency_name` assignment from the `AirtablePipeline`