### PR TITLE
Fix Batch S3 access in cfn template

### DIFF
--- a/city_scrapers/spider.py
+++ b/city_scrapers/spider.py
@@ -9,6 +9,16 @@ import scrapy
 class Spider(scrapy.Spider):
     inflector = Inflector(English)
 
+    def __init__(self, *args, **kwargs):
+        # Add parameters for feed storage in Chicago time
+        tz = timezone('America/Chicago')
+        now = tz.localize(datetime.now())
+        self.year = now.year
+        self.month = now.strftime('%m')
+        self.day = now.strftime('%d')
+        self.hour_min = now.strftime('%H%M')
+        super(Spider, self).__init__(*args, **kwargs)
+
     def _generate_id(self, data, start_time):
         """
         Calulate ID. ID must be unique within the data source being scraped.

--- a/deploy/city_scrapers_cfn.yml
+++ b/deploy/city_scrapers_cfn.yml
@@ -69,6 +69,13 @@ Resources:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
       RoleName: city-scrapers-batch-job-role
+      Policies:
+      - PolicyName: S3ServicePolicy
+        PolicyDocument:
+          Statement:
+          - Effect: Allow
+            Action: ['s3:*']
+            Resource: '*'
   BatchInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/deploy/prod_settings.py
+++ b/deploy/prod_settings.py
@@ -112,4 +112,4 @@ FEED_EXPORTERS = {
 }
 
 FEED_FORMAT = 'cityscrapers_jsonlines'
-FEED_URI = 's3://city-scrapers-events-feed/%(name)s/%(time)s.json'
+FEED_URI = 's3://city-scrapers-events-feed/%(name)s/%(year)s/%(month)s/%(day)s/%(hour_min)s.json'


### PR DESCRIPTION
The export and pipeline from #332 are working, but initially they weren't getting uploaded to S3 because the job role didn't have S3 access. This is already updated on AWS, so if I don't hear anything I'll merge this tomorrow morning. It also adds some params to the `__init__` function so that we have more control of the S3 key generation