### PR TITLE
change git clone to https url

### DIFF
--- a/docs/02_installation.md
+++ b/docs/02_installation.md
@@ -29,7 +29,7 @@ These steps are the same, regardless of which option below you choose.
 
 2. Clone your fork to your local machine:
 ```
-$ git clone git@github.com:<your-username>/city-scrapers.git
+$ git clone https://github.com/YOUR-USERNAME/city-scrapers.git
 ```
 
 3. Change directories into the main project folder:


### PR DESCRIPTION
@o-stovicek pointed out a permissions error while setting up for Codeanywhere, and I realized that we are using the ssh syntax for cloning the project. If we want to keep SSH, we should include instructions for generating a keypair