### PR TITLE
Add pipeline for writing events to S3

### DIFF
--- a/city_scrapers/exporters.py
+++ b/city_scrapers/exporters.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from pytz import timezone
 from scrapy.exporters import JsonLinesItemExporter
 
 

--- a/city_scrapers/pipelines/__init__.py
+++ b/city_scrapers/pipelines/__init__.py
@@ -4,6 +4,7 @@ from .logging import CityScrapersLoggingPipeline
 from .travis import TravisValidationPipeline
 from .csv import CsvPipeline
 from .item import CityScrapersItemPipeline
+from .s3_item import CityScrapersS3ItemPipeline
 
 
 __all__ = (
@@ -12,5 +13,6 @@ __all__ = (
     'GeocoderPipeline',
     'TravisValidationPipeline',
     'CsvPipeline',
-    'CityScrapersItemPipeline'
+    'CityScrapersItemPipeline',
+    'CityScrapersS3ItemPipeline',
 )

--- a/city_scrapers/pipelines/s3_item.py
+++ b/city_scrapers/pipelines/s3_item.py
@@ -1,0 +1,44 @@
+import os
+import json
+import boto3
+from botocore.exceptions import ClientError
+from datetime import datetime
+
+from scrapy.utils.project import get_project_settings
+
+s3_client = boto3.client('s3')
+settings = get_project_settings()
+
+
+class CityScrapersS3ItemPipeline(object):
+    """
+    Pipeline for writing each individual meeting to an S3 bucket
+    with its ID as the key. Checks if the key exists, and only
+    updates it if it does if the contents have changed
+    """
+    def process_item(self, item, spider):
+        item_obj = item.copy()
+        for k, v in item_obj.items():
+            if isinstance(v, datetime):
+                item_obj[k] = v.strftime('%Y-%m-%dT%H:%M:%S')
+        bucket = settings.get('S3_ITEM_BUCKET')
+        item_key = item_obj['id'] + '.json'
+
+        put_s3_item = None
+        try:
+            s3_item_obj = s3_client.get_object(Bucket=bucket, Key=item_key)
+            s3_item_obj = json.loads(s3_item_obj['Body'].read().decode('utf-8'))
+            if item_obj != s3_item_obj:
+                put_s3_item = item_obj
+        except ClientError:
+            put_s3_item = item_obj
+
+        if put_s3_item is None:
+            return item
+
+        s3_client.put_object(
+            Bucket=settings.get('S3_ITEM_BUCKET'),
+            Key=item_obj['id'] + '.json',
+            Body=json.dumps(put_s3_item).encode(),
+        )
+        return item

--- a/city_scrapers/settings/base.py
+++ b/city_scrapers/settings/base.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 
 # Scrapy settings for city_scrapers project
 #
@@ -27,7 +28,8 @@ COOKIES_ENABLED = False
 
 # Configure item pipelines
 ITEM_PIPELINES = {
-#    'city_scrapers.pipelines.CsvPipeline': 400
+    'city_scrapers.pipelines.CityScrapersItemPipeline': 200,
+    # 'city_scrapers.pipelines.CsvPipeline': 400,
 }
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
@@ -96,3 +98,5 @@ CLOSESPIDER_ERRORCOUNT = 5
 #HTTPCACHE_DIR = 'httpcache'
 #HTTPCACHE_IGNORE_HTTP_CODES = []
 #HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
+
+S3_ITEM_BUCKET = os.getenv('S3_ITEM_BUCKET', 'city-scrapers-meetings-staging')

--- a/city_scrapers/settings/prod.py
+++ b/city_scrapers/settings/prod.py
@@ -14,6 +14,7 @@ ITEM_PIPELINES = {
     # disabled until we can rebuild it on another provider
     #'city_scrapers.pipelines.GeocoderPipeline': 200,
     'city_scrapers.pipelines.CityScrapersItemPipeline': 200,
+    'city_scrapers.pipelines.CityScrapersS3ItemPipeline': 300,
     'city_scrapers.pipelines.AirtablePipeline': 400
 }
 


### PR DESCRIPTION
In addition to the feed export of each run of a given spider, write each individual meeting to S3, only updating keys that either don't exist or have changed. This is for the documenters platform, which adds any updated keys in this bucket to an SQS queue.

If the tests pass on this I'll merge it later today if no one has any issues with it