### PR TITLE
Add decorator to catch pipeline errors

### DIFF
--- a/city_scrapers/pipelines/item.py
+++ b/city_scrapers/pipelines/item.py
@@ -1,9 +1,14 @@
+from city_scrapers.utils import report_error
+
+@report_error
 class CityScrapersItemPipeline(object):
     """
     Pipeline for doing any custom processing on individual
     items, i.e. assigning the long name to agency_name
     """
     def process_item(self, item, spider):
+        raise Exception("HELLO")
+        
         if hasattr(spider, 'long_name'):
             item['agency_name'] = spider.long_name
         else:

--- a/city_scrapers/pipelines/item.py
+++ b/city_scrapers/pipelines/item.py
@@ -1,14 +1,14 @@
 from city_scrapers.utils import report_error
 
-@report_error
 class CityScrapersItemPipeline(object):
     """
     Pipeline for doing any custom processing on individual
     items, i.e. assigning the long name to agency_name
     """
+    @report_error
     def process_item(self, item, spider):
         raise Exception("HELLO")
-        
+
         if hasattr(spider, 'long_name'):
             item['agency_name'] = spider.long_name
         else:

--- a/city_scrapers/pipelines/item.py
+++ b/city_scrapers/pipelines/item.py
@@ -7,8 +7,6 @@ class CityScrapersItemPipeline(object):
     """
     @report_error
     def process_item(self, item, spider):
-        raise Exception("HELLO")
-
         if hasattr(spider, 'long_name'):
             item['agency_name'] = spider.long_name
         else:

--- a/city_scrapers/spiders/chi_library.py
+++ b/city_scrapers/spiders/chi_library.py
@@ -9,6 +9,7 @@ import json
 import datetime
 
 from city_scrapers.spider import Spider
+from city_scrapers.utils import report_error
 
 
 class Chi_librarySpider(Spider):
@@ -24,7 +25,9 @@ class Chi_librarySpider(Spider):
         """
         self.session = session
 
+    @report_error
     def parse(self, response):
+        raise Exception("HELLO")
         """
         `parse` should always `yield` a dict that follows the `Open Civic Data
         event standard <http://docs.opencivicdata.org/en/latest/data/event.html>`_.

--- a/city_scrapers/spiders/chi_library.py
+++ b/city_scrapers/spiders/chi_library.py
@@ -9,7 +9,6 @@ import json
 import datetime
 
 from city_scrapers.spider import Spider
-from city_scrapers.utils import report_error
 
 
 class Chi_librarySpider(Spider):
@@ -25,9 +24,7 @@ class Chi_librarySpider(Spider):
         """
         self.session = session
 
-    @report_error
     def parse(self, response):
-        raise Exception("HELLO")
         """
         `parse` should always `yield` a dict that follows the `Open Civic Data
         event standard <http://docs.opencivicdata.org/en/latest/data/event.html>`_.

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -22,17 +22,12 @@ def report_error(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         try:
-            print('Calling decorated function')
             return f(*args, **kwargs)
         except:
-            print('Reporting to Sentry')
-            # TODO: Report to Sentry
             get_client().captureException(extra={
                 'args': args,
                 'kwargs': kwargs
             })
-            print('Done reporting to Sentry')
-
             raise
 
     return wrapper

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -24,14 +24,13 @@ def report_error(f):
         try:
             print('Calling decorated function')
             return f(*args, **kwds)
+            print("THIS NEVER GETS ")
         except:
             print('Reporting to Sentry')
             # TODO: Report to Sentry
             get_client().captureException()
             print('Done reporting to Sentry')
-            
+
             raise
 
     return wrapper
-
-    

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -27,7 +27,10 @@ def report_error(f):
         except:
             print('Reporting to Sentry')
             # TODO: Report to Sentry
-            get_client().captureException()
+            get_client().captureException(extra={
+                'args': args,
+                'kwargs': kwargs
+            })
             print('Done reporting to Sentry')
 
             raise

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -1,4 +1,5 @@
 from functools import reduce
+from functools import wraps
 from operator import getitem
 
 
@@ -15,3 +16,17 @@ def get_key(the_dict, location_string):
         return reduce(getitem, location_string.split('.'), the_dict) or ''
     except (KeyError, TypeError):
         return None
+
+def report_error(f):
+    @wraps(f)
+    def wrapper(*args, **kwds):
+        try:
+            print('Calling decorated function')
+            return f(*args, **kwds)
+        except:
+            # TODO: Report to Sentry
+            print('Reporting to Sentry')
+            raise
+
+    return wrapper
+    

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -1,6 +1,7 @@
 from functools import reduce
 from functools import wraps
 from operator import getitem
+from scrapy_sentry.utils import get_client
 
 
 def get_key(the_dict, location_string):
@@ -26,6 +27,8 @@ def report_error(f):
         except:
             # TODO: Report to Sentry
             print('Reporting to Sentry')
+            get_client().captureException()
+            print('Done reporting to Sentry')
             raise
 
     return wrapper

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -20,10 +20,10 @@ def get_key(the_dict, location_string):
 
 def report_error(f):
     @wraps(f)
-    def wrapper(*args, **kwds):
+    def wrapper(*args, **kwargs):
         try:
             print('Calling decorated function')
-            return f(*args, **kwds)
+            return f(*args, **kwargs)
         except:
             print('Reporting to Sentry')
             # TODO: Report to Sentry

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -24,7 +24,6 @@ def report_error(f):
         try:
             print('Calling decorated function')
             return f(*args, **kwds)
-            print("THIS NEVER GETS ")
         except:
             print('Reporting to Sentry')
             # TODO: Report to Sentry

--- a/city_scrapers/utils.py
+++ b/city_scrapers/utils.py
@@ -25,11 +25,13 @@ def report_error(f):
             print('Calling decorated function')
             return f(*args, **kwds)
         except:
-            # TODO: Report to Sentry
             print('Reporting to Sentry')
+            # TODO: Report to Sentry
             get_client().captureException()
             print('Done reporting to Sentry')
+            
             raise
 
     return wrapper
+
     


### PR DESCRIPTION
Uses Python's `functools` library to create a decorator that will catch, report to Sentry and re-raise any exception that surfaces in the wrapped method.

Adding screenshots below to demonstrate what data shows in Sentry.

Please let me know if I should add the code to put the decorator on all the pipelines.

<img width="855" alt="exception-pipeline-name" src="https://user-images.githubusercontent.com/131699/43362601-f67644be-92b3-11e8-8f75-6f14846c391e.png">

^ shown stack trace is from the correct location and shows the pipeline name.

<img width="861" alt="exception-item" src="https://user-images.githubusercontent.com/131699/43362602-f9b5d7e8-92b3-11e8-9e8f-1c96e93c57f9.png">

^ extra data includes all the inputs to the wrapped function (in this case the item being passed to the pipeline)
