### PR TITLE
Change S3 item pipeline import for logging

### DIFF
--- a/city_scrapers/pipelines/__init__.py
+++ b/city_scrapers/pipelines/__init__.py
@@ -4,7 +4,6 @@ from .logging import CityScrapersLoggingPipeline
 from .travis import TravisValidationPipeline
 from .csv import CsvPipeline
 from .item import CityScrapersItemPipeline
-from .s3_item import CityScrapersS3ItemPipeline
 
 
 __all__ = (
@@ -14,5 +13,4 @@ __all__ = (
     'TravisValidationPipeline',
     'CsvPipeline',
     'CityScrapersItemPipeline',
-    'CityScrapersS3ItemPipeline',
 )

--- a/city_scrapers/settings/prod.py
+++ b/city_scrapers/settings/prod.py
@@ -14,7 +14,7 @@ ITEM_PIPELINES = {
     # disabled until we can rebuild it on another provider
     #'city_scrapers.pipelines.GeocoderPipeline': 200,
     'city_scrapers.pipelines.CityScrapersItemPipeline': 200,
-    'city_scrapers.pipelines.CityScrapersS3ItemPipeline': 300,
+    'city_scrapers.pipelines.s3_item.CityScrapersS3ItemPipeline': 300,
     'city_scrapers.pipelines.AirtablePipeline': 400
 }
 


### PR DESCRIPTION
Fixes the logging errors in #432. Because the S3 item pipeline was getting imported from the `pipelines` `__init__` file, all Scrapy environments were trying to load `boto3` and logging errors when it failed to find AWS credentials set up locally.

I split out the import so that it's only included in the production environment, and now I don't see any `boto3` logs locally when running spiders in development (I saw logs for it before, but they didn't throw errors)