### PR TITLE
Add 'Chicago, IL' to spider addresses

### DIFF
--- a/city_scrapers/spiders/chi_police.py
+++ b/city_scrapers/spiders/chi_police.py
@@ -113,11 +113,15 @@ class Chi_policeSpider(Spider):
 
     def _parse_location(self, item):
         """
-        Parse or generate location. Url, latitutde and longitude are all
-        optional and may be more trouble than they're worth to collect.
+        Parses location, adding Chicago, IL to the end of the address
+        since it isn't included but can be safely assumed.
         """
+        if item['location']:
+            address = item['location'] + ' Chicago, IL'
+        else:
+            address = None
         return {
-            'address': item['location'],
+            'address': address,
             'name': '',
             'neighborhood': ''
         }

--- a/city_scrapers/spiders/chi_school_actions.py
+++ b/city_scrapers/spiders/chi_school_actions.py
@@ -129,12 +129,13 @@ class ChiSchoolActionsSpider(Spider):
     @staticmethod
     def _parse_location(item):
         """
-        Parse or generate location. Latitude and longitude can be
-        left blank and will be geocoded later.
+        Parses location, adding Chicago, IL to the end of the address
+        since it isn't included but can be safely assumed.
         """
+        address = item.css('.addr2::text').extract_first()
         return {
             'name': item.css('.addr::text').extract_first(),
-            'address': item.css('.addr2::text').extract_first(),
+            'address': address + ' Chicago, IL',
             'neighborhood': '',
         }
 

--- a/tests/test_chi_police.py
+++ b/tests/test_chi_police.py
@@ -64,7 +64,7 @@ def test_documents():
 
 def test_location():
     EXPECTED_LOCATION = {
-            'address': "St. Ferdinand's3115 N. Mason",
+            'address': "St. Ferdinand's3115 N. Mason Chicago, IL",
             'name': '',
             'neighborhood': ''
     }

--- a/tests/test_chi_school_actions.py
+++ b/tests/test_chi_school_actions.py
@@ -48,7 +48,7 @@ def test_id():
 def test_location():
     assert parsed_items[0]['location'] == {
         'name': 'Rosario Castellanos ES',
-        'address': '2524 S Central Park Ave',
+        'address': '2524 S Central Park Ave Chicago, IL',
         'neighborhood': '',
     }
 


### PR DESCRIPTION
Closes #454. Adds "Chicago, IL" by default to the end of the CAPS and school action spiders since they don't include city or state information. Will merge tonight or tomorrow if no one has any issues