### PR TITLE
Update job definitions and scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.pytest_cache
 *.cover
 .hypothesis/
 

--- a/deploy/city_scrapers_cfn.yml
+++ b/deploy/city_scrapers_cfn.yml
@@ -163,17 +163,27 @@ Resources:
 
           def handler(event, context):
               try:
-                  job_defs = batch.describe_job_definitions(status='ACTIVE')['jobDefinitions']
-                  active_job_defs = set([job['jobDefinitionName'] for job in job_defs])
-
-                  for job in active_job_defs:
-                      response = batch.submit_job(
-                          jobName='{}-job'.format(job),
-                          jobQueue=JOB_QUEUE,
-                          jobDefinition=job,
-                          retryStrategy={'attempts': 3}
+                  job_def_res = batch.describe_job_definitions()
+                  job_defs = job_def_res['jobDefinitions']
+                  while 'nextToken' in job_def_res:
+                      job_def_res = batch.describe_job_definitions(
+                          nextToken=job_def_res['nextToken'],
                       )
-                      print(response)
+                      job_defs.extend(job_def_res['jobDefinitions'])
+
+                  job_defs = set([job['jobDefinitionName'] for job in job_defs])
+
+                  for job in job_defs:
+                      try:
+                          response = batch.submit_job(
+                              jobName='{}-job'.format(job),
+                              jobQueue=JOB_QUEUE,
+                              jobDefinition=job,
+                              retryStrategy={'attempts': 3}
+                          )
+                          print(response)
+                      except batch.exceptions.ClientException as e:
+                          pass
               except Exception as e:
                   print(e)
                   raise e


### PR DESCRIPTION
Batch isn't returning every active job in an intuitive way, so this still deregisters active jobs but then attempts to schedule every job name so that we can make sure all of the scrapers run. Also adds `.pytest_cache` to the `.gitignore` which only popped up for me recently.

This is already running on the Lambda, so I'll merge this tomorrow if no one has any objections