### PR TITLE
Clean up cancellation strings in item names

### DIFF
--- a/city_scrapers/pipelines/item.py
+++ b/city_scrapers/pipelines/item.py
@@ -4,12 +4,14 @@ from city_scrapers.utils import report_error
 class CityScrapersItemPipeline(object):
     """
     Pipeline for doing any custom processing on individual
-    items, i.e. assigning the long name to agency_name
+    items
     """
     @report_error
     def process_item(self, item, spider):
-        if hasattr(spider, 'long_name'):
-            item['agency_name'] = spider.long_name
-        else:
-            item['agency_name'] = spider.agency_name
+        item['agency_name'] = spider.agency_name
+        # Remove cancellation from names, update ID if changed
+        cleaned_name = spider._clean_name(item['name'])
+        if cleaned_name != item['name']:
+            item['name'] = cleaned_name
+            item['id'] = spider._generate_id(item)
         return item

--- a/city_scrapers/spiders/chi_animal.py
+++ b/city_scrapers/spiders/chi_animal.py
@@ -103,10 +103,10 @@ class ChiAnimalSpider(Spider):
         """
         Parse start date and time.
         """
-        naive_datetime = self._naive_datetime_to_tz(dateparse(item))
+        dt = dateparse(item)
         return {
-            'date': naive_datetime.date(),
-            'time': naive_datetime.time(),
+            'date': dt.date(),
+            'time': dt.time(),
         }
 
     def _generate_end(self, start):

--- a/city_scrapers/spiders/il_metra_board.py
+++ b/city_scrapers/spiders/il_metra_board.py
@@ -84,16 +84,14 @@ class IlMetraBoardSpider(Spider):
             return None
 
         try:
-            naive = datetime.strptime(date_time_str, '%b %d, %Y - %I:%M %p')
+            dt = datetime.strptime(date_time_str, '%b %d, %Y - %I:%M %p')
             return {
-                'date': naive.date(),
-                'time': naive.time(),
+                'date': dt.date(),
+                'time': dt.time(),
                 'note': '',
             }
         except ValueError:
             return None
-
-        return self._naive_datetime_to_tz(naive, 'America/Chicago')
 
     def _parse_documents(self, item):
         """Parse documents from current and past meetings"""

--- a/tests/test_pipeline_localexport.py
+++ b/tests/test_pipeline_localexport.py
@@ -10,8 +10,7 @@ testSpider = ChiBuildingsSpider()
 def _str_to_datetime(date_string, spider_in=testSpider):
     if not date_string:
         return testSpider
-    naive = datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S')
-    return spider_in._naive_datetime_to_tz(naive)
+    return datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S')
 
 
 def load_valid_item():


### PR DESCRIPTION
* Removes `_naive_datetime_to_tz` since it's not longer needed
* Adds `_clean_name` to base spider which removes strings mentioning cancellation or rescheduling from a meeting's name so that the original ID isn't changed
* Updates the item pipeline to apply these changes to each item so spiders don't have to be changed