### PR TITLE
Fix cancellations, update Low Income Housing Trust

### DIFF
--- a/city_scrapers/spiders/chi_low_income_housing_trust_fund.py
+++ b/city_scrapers/spiders/chi_low_income_housing_trust_fund.py
@@ -1,16 +1,15 @@
-# -*- coding: utf-8 -*-
 import re
 from datetime import datetime
 
 import scrapy
+from city_scrapers_core.constants import BOARD, COMMITTEE, NOT_CLASSIFIED
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
 
-from city_scrapers.constants import BOARD, COMMITTEE, NOT_CLASSIFIED
-from city_scrapers.spider import Spider
 
-
-class ChiLowIncomeHousingTrustFundSpider(Spider):
+class ChiLowIncomeHousingTrustFundSpider(CityScrapersSpider):
     name = 'chi_low_income_housing_trust_fund'
-    agency_name = 'Chicago Low-Income Housing Trust Fund'
+    agency = 'Chicago Low-Income Housing Trust Fund'
     timezone = 'America/Chicago'
     allowed_domains = ['www.chicagotrustfund.org']
     start_urls = ['http://www.chicagotrustfund.org/about-us/upcomingevents/']
@@ -18,16 +17,15 @@ class ChiLowIncomeHousingTrustFundSpider(Spider):
 
     def parse(self, response):
         """
-        `parse` should always `yield` a dict that follows the Event Schema
-        <https://city-bureau.github.io/city-scrapers/06_event_schema.html>.
+        `parse` should always `yield` Meeting items.
 
-        Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
         needs.
         """
         items = self._parse_calendar(response)
         for item in items:
             req = scrapy.Request(
-                item['sources'][0]['url'],
+                item['source'],
                 callback=self._parse_detail,
                 dont_filter=True,
             )
@@ -49,82 +47,64 @@ class ChiLowIncomeHousingTrustFundSpider(Spider):
     def _parse_calendar(self, response):
         """Parse items on the main calendar page"""
         items = []
-        for item in response.css('.day-with-date:not(.no-events)'):
-            name = self._parse_name(item)
+        for item in response.css('.day-with-date:not(.no-events), .current-day:not(.no-events)'):
+            title = self._parse_title(item)
             description = self._parse_description(item)
-            sources = self._parse_sources(item, response.url)
-            items.append({
-                '_type': 'event',
-                'name': name,
-                'event_description': description,
-                'classification': self._parse_classification(name),
-                'all_day': False,
-                'documents': [],
-                'sources': sources,
-            })
+            items.append(
+                Meeting(
+                    title=title,
+                    description=description,
+                    classification=self._parse_classification(title),
+                    all_day=False,
+                    links=[],
+                    source=self._parse_source(item, response.url),
+                )
+            )
         return items
 
     def _parse_detail(self, response):
         """Parse detail page for additional information"""
-        data = {
-            **response.meta.get('item', {}),
-            **self._parse_start_end_time(response),
-            'location': self._parse_location(response),
-        }
-        data['status'] = self._generate_status(data)
-        data['id'] = self._generate_id(data)
-        return data
+        meeting = response.meta.get('item', {})
+        meeting.update(self._parse_start_end_time(response))
+        meeting['location'] = self._parse_location(response)
+        meeting['status'] = self._get_status(meeting)
+        meeting['id'] = self._get_id(meeting)
+        return meeting
 
-    def _parse_name(self, item):
-        """
-        Parse or generate event name.
-        """
+    def _parse_title(self, item):
+        """Parse or generate event title"""
         return item.css('.event-title::text').extract_first()
 
     def _parse_description(self, item):
-        """
-        Parse or generate event description.
-        """
+        """Parse or generate event description"""
         return item.xpath('.//span[@class="event-content-break"]/following-sibling::text()'
                           ).extract_first()
 
-    def _parse_classification(self, name):
-        """
-        Parse or generate classification (e.g. board, committee, etc).
-        """
-        if 'board' in name.lower():
+    def _parse_classification(self, title):
+        """Parse or generate classification (e.g. board, committee, etc)"""
+        if 'board' in title.lower():
             return BOARD
-        if 'committee' in name.lower():
+        if 'committee' in title.lower():
             return COMMITTEE
         return NOT_CLASSIFIED
 
     def _parse_start_end_time(self, response):
-        """
-        Parse start date and time.
-        """
+        """Parse start and end datetimes"""
         time_str = response.css('.cc-panel .cc-block > span::text').extract_first()
         time_str = re.sub(r'\s+', ' ', time_str)
         date_str = re.search(r'(?<=day, ).*(?= fro)', time_str).group().strip()
         start_str = re.search(r'(?<=from ).*(?= to)', time_str).group().strip()
         end_str = re.search(r'(?<=to ).*(?= \w{3})', time_str).group().strip()
-        dt = datetime.strptime(date_str, '%B %d, %Y').date()
+        date_obj = datetime.strptime(date_str, '%B %d, %Y').date()
+        start_time = datetime.strptime(start_str, '%I:%M %p').time()
+        end_time = datetime.strptime(end_str, '%I:%M %p').time()
         return {
-            'start': {
-                'date': dt,
-                'time': datetime.strptime(start_str, '%I:%M %p').time(),
-                'note': '',
-            },
-            'end': {
-                'date': dt,
-                'time': datetime.strptime(end_str, '%I:%M %p').time(),
-                'note': '',
-            }
+            'start': datetime.combine(date_obj, start_time),
+            'end': datetime.combine(date_obj, end_time),
         }
 
     def _parse_location(self, response):
-        """
-        Parse or generate location.
-        """
+        """Parse or generate location"""
         addr_sel = response.css('.cc-panel .cc-block:nth-child(2) > span:nth-of-type(2)::text')
         if not addr_sel:
             addr_sel = response.css('#span_event_where_multiline p:first-of-type::text')
@@ -132,14 +112,11 @@ class ChiLowIncomeHousingTrustFundSpider(Spider):
         return {
             'address': ' '.join([re.sub(r'\s+', ' ', line).strip() for line in addr_lines]),
             'name': '',
-            'neighborhood': '',
         }
 
-    def _parse_sources(self, item, response_url):
-        """
-        Parse or generate sources.
-        """
+    def _parse_source(self, item, response_url):
+        """Parse or generate source"""
         item_link = item.css('.calnk > a::attr(href)').extract_first()
         if item_link:
-            return [{'url': item_link, 'note': ''}]
-        return [{'url': response_url, 'note': ''}]
+            return item_link
+        return response_url

--- a/tests/test_chi_low_income_housing_trust_fund.py
+++ b/tests/test_chi_low_income_housing_trust_fund.py
@@ -1,10 +1,11 @@
-from datetime import date, time
+from datetime import datetime
+from os.path import dirname, join
 
 import pytest
+from city_scrapers_core.constants import BOARD, COMMITTEE, PASSED
+from city_scrapers_core.utils import file_response
 from freezegun import freeze_time
-from tests.utils import file_response
 
-from city_scrapers.constants import BOARD, COMMITTEE, PASSED
 from city_scrapers.spiders.chi_low_income_housing_trust_fund import (
     ChiLowIncomeHousingTrustFundSpider
 )
@@ -12,27 +13,29 @@ from city_scrapers.spiders.chi_low_income_housing_trust_fund import (
 freezer = freeze_time('2018-10-31')
 freezer.start()
 spider = ChiLowIncomeHousingTrustFundSpider()
-cal_res = file_response('files/chi_low_income_housing_trust_fund.html')
+cal_res = file_response(join(dirname(__file__), 'files', 'chi_low_income_housing_trust_fund.html'))
 parsed_items = []
 for item in spider._parse_calendar(cal_res):
-    detail_res = file_response('files/chi_low_income_housing_trust_fund_detail.html')
+    detail_res = file_response(
+        join(dirname(__file__), 'files', 'chi_low_income_housing_trust_fund_detail.html')
+    )
     detail_res.meta['item'] = item
     parsed_items.append(spider._parse_detail(detail_res))
 freezer.stop()
 
 
-def test_name():
-    assert parsed_items[0]['name'] == 'Finance Committee'
-    assert parsed_items[1]['name'] == 'Allocations Committee'
-    assert parsed_items[2]['name'] == 'Board Meeting'
+def test_title():
+    assert parsed_items[0]['title'] == 'Finance Committee'
+    assert parsed_items[1]['title'] == 'Allocations Committee'
+    assert parsed_items[2]['title'] == 'Board Meeting'
 
 
 def test_start():
-    assert parsed_items[0]['start'] == {'date': date(2018, 10, 4), 'time': time(10, 0), 'note': ''}
+    assert parsed_items[0]['start'] == datetime(2018, 10, 4, 10, 0)
 
 
 def test_end():
-    assert parsed_items[0]['end'] == {'date': date(2018, 10, 4), 'time': time(11, 0), 'note': ''}
+    assert parsed_items[0]['end'] == datetime(2018, 10, 4, 11, 0)
 
 
 def test_id():
@@ -51,7 +54,7 @@ def test_status():
 
 
 def test_description():
-    assert parsed_items[0]['event_description'] == (
+    assert parsed_items[0]['description'] == (
         'Meeting of the CLIHTF Finance Committee.  To attend, send Name and '
         'Planned Attendance Date to info@chicagotrustfund.org.  Regular '
         'Meeting Location:  Chicago City Hall, Rm. 1006c.'
@@ -62,25 +65,14 @@ def test_location():
     assert parsed_items[0]['location'] == {
         'address': '121 N. La Salle - Room 1006 Chicago, IL 60602',
         'name': '',
-        'neighborhood': '',
     }
 
 
 @pytest.mark.parametrize('item', parsed_items)
-def test_documents(item):
-    assert item['documents'] == []
+def test_links(item):
+    assert item['links'] == []
 
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_all_day(item):
     assert item['all_day'] is False
-
-
-@pytest.mark.parametrize('item', parsed_items)
-def test_sources(item):
-    assert len(item['sources']) == 1
-
-
-@pytest.mark.parametrize('item', parsed_items)
-def test__type(item):
-    assert item['_type'] == 'event'


### PR DESCRIPTION
Same day meetings were being cancelled in `chi_low_income_housing_trust_fund` because the selector wasn't looking for events under the selector `.current-day`. That's added here, and the spider is updated to use the `city_scrapers_core` setup