### PR TITLE
Fix several broken scrapers, update core version

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -37,17 +37,17 @@
         },
         "azure-common": {
             "hashes": [
-                "sha256:5dd7ed46da968814020ecd961e7496f0a4f5e59f6d452df02100218145f6d1ba",
-                "sha256:e7cd5a8ee2ec0639454c1bd0f1ea5f609d83977376abfd304527ec7343fef1be"
+                "sha256:5cb223c1b52deb8ff9304387201bab83950787be9ca2e8733220726740cc40d0",
+                "sha256:5fd62ae10b1add97d3c69af970328ec3bd869184396bcf6bfa9c7bc94d688424"
             ],
-            "version": "==1.1.17"
+            "version": "==1.1.18"
         },
         "azure-storage-blob": {
             "hashes": [
-                "sha256:65ebe2e54460566c2077c6b3773a2a0623eabc7b95602010cb51b84077087fda",
-                "sha256:baa828607e21e5c7b6ceb2ede9894d465adf586373c2f7c988fe55eca8e9048c"
+                "sha256:6577e9ebca6fd1cf47795f88a1f0949c003fae62eeb6479a05631b765cf73b80",
+                "sha256:f187a878e7a191f4e098159904f72b4146cf70e1aabaf6484ab4ba72fc6f252c"
             ],
-            "version": "==1.4.0"
+            "version": "==1.5.0"
         },
         "azure-storage-common": {
             "hashes": [
@@ -65,40 +65,36 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743",
-                "sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef",
-                "sha256:1b0493c091a1898f1136e3f4f991a784437fac3673780ff9de3bcf46c80b6b50",
-                "sha256:2ba8a45822b7aee805ab49abfe7eec16b90587f7f26df20c71dd89e45a97076f",
-                "sha256:3bb6bd7266598f318063e584378b8e27c67de998a43362e8fce664c54ee52d30",
-                "sha256:3c85641778460581c42924384f5e68076d724ceac0f267d66c757f7535069c93",
-                "sha256:3eb6434197633b7748cea30bf0ba9f66727cdce45117a712b29a443943733257",
-                "sha256:495c5c2d43bf6cebe0178eb3e88f9c4aa48d8934aa6e3cddb865c058da76756b",
-                "sha256:4c91af6e967c2015729d3e69c2e51d92f9898c330d6a851bf8f121236f3defd3",
-                "sha256:57b2533356cb2d8fac1555815929f7f5f14d68ac77b085d2326b571310f34f6e",
-                "sha256:770f3782b31f50b68627e22f91cb182c48c47c02eb405fd689472aa7b7aa16dc",
-                "sha256:79f9b6f7c46ae1f8ded75f68cf8ad50e5729ed4d590c74840471fc2823457d04",
-                "sha256:7a33145e04d44ce95bcd71e522b478d282ad0eafaf34fe1ec5bbd73e662f22b6",
-                "sha256:857959354ae3a6fa3da6651b966d13b0a8bed6bbc87a0de7b38a549db1d2a359",
-                "sha256:87f37fe5130574ff76c17cab61e7d2538a16f843bb7bca8ebbc4b12de3078596",
-                "sha256:95d5251e4b5ca00061f9d9f3d6fe537247e145a8524ae9fd30a2f8fbce993b5b",
-                "sha256:9d1d3e63a4afdc29bd76ce6aa9d58c771cd1599fbba8cf5057e7860b203710dd",
-                "sha256:a36c5c154f9d42ec176e6e620cb0dd275744aa1d804786a71ac37dc3661a5e95",
-                "sha256:a6a5cb8809091ec9ac03edde9304b3ad82ad4466333432b16d78ef40e0cce0d5",
-                "sha256:ae5e35a2c189d397b91034642cb0eab0e346f776ec2eb44a49a459e6615d6e2e",
-                "sha256:b0f7d4a3df8f06cf49f9f121bead236e328074de6449866515cea4907bbc63d6",
-                "sha256:b75110fb114fa366b29a027d0c9be3709579602ae111ff61674d28c93606acca",
-                "sha256:ba5e697569f84b13640c9e193170e89c13c6244c24400fc57e88724ef610cd31",
-                "sha256:be2a9b390f77fd7676d80bc3cdc4f8edb940d8c198ed2d8c0be1319018c778e1",
-                "sha256:ca1bd81f40adc59011f58159e4aa6445fc585a32bb8ac9badf7a2c1aa23822f2",
-                "sha256:d5d8555d9bfc3f02385c1c37e9f998e2011f0db4f90e250e5bc0c0a85a813085",
-                "sha256:e55e22ac0a30023426564b1059b035973ec82186ddddbac867078435801c7801",
-                "sha256:e90f17980e6ab0f3c2f3730e56d1fe9bcba1891eeea58966e89d352492cc74f4",
-                "sha256:ecbb7b01409e9b782df5ded849c178a0aa7c906cf8c5a67368047daab282b184",
-                "sha256:ed01918d545a38998bfa5902c7c00e0fee90e957ce036a4000a88e3fe2264917",
-                "sha256:edabd457cd23a02965166026fd9bfd196f4324fe6032e866d0f3bd0301cd486f",
-                "sha256:fdf1c1dc5bafc32bc5d08b054f94d659422b05aba244d6be4ddc1c72d9aa70fb"
+                "sha256:0b5f895714a7a9905148fc51978c62e8a6cbcace30904d39dcd0d9e2265bb2f6",
+                "sha256:27cdc7ba35ee6aa443271d11583b50815c4bb52be89a909d0028e86c21961709",
+                "sha256:2d4a38049ea93d5ce3c7659210393524c1efc3efafa151bd85d196fa98fce50a",
+                "sha256:3262573d0d60fc6b9d0e0e6e666db0e5045cbe8a531779aa0deb3b425ec5a282",
+                "sha256:358e96cfffc185ab8f6e7e425c7bb028931ed08d65402fbcf3f4e1bff6e66556",
+                "sha256:37c7db824b5687fbd7ea5519acfd054c905951acc53503547c86be3db0580134",
+                "sha256:39b9554dfe60f878e0c6ff8a460708db6e1b1c9cc6da2c74df2955adf83e355d",
+                "sha256:42b96a77acf8b2d06821600fa87c208046decc13bd22a4a0e65c5c973443e0da",
+                "sha256:5b37dde5035d3c219324cac0e69d96495970977f310b306fa2df5910e1f329a1",
+                "sha256:5d35819f5566d0dd254f273d60cf4a2dcdd3ae3003dfd412d40b3fe8ffd87509",
+                "sha256:5df73aa465e53549bd03c819c1bc69fb85529a5e1a693b7b6cb64408dd3970d1",
+                "sha256:7075b361f7a4d0d4165439992d0b8a3cdfad1f302bf246ed9308a2e33b046bd3",
+                "sha256:7678b5a667b0381c173abe530d7bdb0e6e3b98e062490618f04b80ca62686d96",
+                "sha256:7dfd996192ff8a535458c17f22ff5eb78b83504c34d10eefac0c77b1322609e2",
+                "sha256:8a3be5d31d02c60f84c4fd4c98c5e3a97b49f32e16861367f67c49425f955b28",
+                "sha256:9812e53369c469506b123aee9dcb56d50c82fad60c5df87feb5ff59af5b5f55c",
+                "sha256:9b6f7ba4e78c52c1a291d0c0c0bd745d19adde1a9e1c03cb899f0c6efd6f8033",
+                "sha256:a85bc1d7c3bba89b3d8c892bc0458de504f8b3bcca18892e6ed15b5f7a52ad9d",
+                "sha256:aa6b9c843ad645ebb12616de848cc4e25a40f633ccc293c3c9fe34107c02c2ea",
+                "sha256:bae1aa56ee00746798beafe486daa7cfb586cd395c6ce822ba3068e48d761bc0",
+                "sha256:bae96e26510e4825d5910a196bf6b5a11a18b87d9278db6d08413be8ea799469",
+                "sha256:bd78df3b594013b227bf31d0301566dc50ba6f40df38a70ded731d5a8f2cb071",
+                "sha256:c2711197154f46d06f73542c539a0ff5411f1951fab391e0a4ac8359badef719",
+                "sha256:d998c20e3deed234fca993fd6c8314cb7cbfda05fd170f1bd75bb5d7421c3c5a",
+                "sha256:df4f840d77d9e37136f8e6b432fecc9d6b8730f18f896e90628712c793466ce6",
+                "sha256:f5653c2581acb038319e6705d4e3593677676df14b112f13e0b5b44b6a18df1a",
+                "sha256:f7c7aa485a2e2250d455148470ffd0195eecc3d845122635202d7467d6f7b4cf",
+                "sha256:f9e2c66a6493147de835f207f198540a56b26745ce4f272fbc7c2f2cfebeb729"
             ],
-            "version": "==1.11.5"
+            "version": "==1.12.1"
         },
         "chardet": {
             "hashes": [
@@ -112,11 +108,11 @@
                 "azure"
             ],
             "hashes": [
-                "sha256:2ed99c111ee041d317e08b1ad1ba9a0fffe89cb2f227b16fbcdfbd805fcab216",
-                "sha256:a37153c08c7e7d6f3dd3a5629084a50946583fdbb0471bcacdab64b2146e5ccd"
+                "sha256:b3934c7f6efcc175814fb035c4b1eeb0aab5140d2968110b01be73af5ef128f8",
+                "sha256:c08bb91676e5a7d208f1a48102883ffb24fda6dd34e932f99d8c63819d216d57"
             ],
             "index": "pypi",
-            "version": "==0.2.1"
+            "version": "==0.2.2"
         },
         "constantly": {
             "hashes": [
@@ -194,45 +190,45 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:3eae63135c4a2cd15ecfd1424494494be77bd8a27014c44c8c2343e61d908770",
-                "sha256:8ba4f6c03b9db02e51f4a21579b7b0364b7c174361998888fb5d18fab4ed73f1"
+                "sha256:683fe7ed58763ea0be572de5aad47cd3cc1297640916f9a8ccd222b287da7d2f",
+                "sha256:b42d7a292addb57370e6260bcbadb77e00a899fe6ec998c453f45893c41c658b"
             ],
-            "version": "==3.0.0b1"
+            "version": "==3.0.0b3"
         },
         "legistar": {
             "git": "https://github.com/opencivicdata/python-legistar-scraper",
-            "ref": "bf25cc94980f1608b4cc6766529f1155a273e049"
+            "ref": "d9170cbf43fada60b2edfc75b2d0f86ad9e8179d"
         },
         "lxml": {
             "hashes": [
-                "sha256:0dd6589fa75d369ba06d2b5f38dae107f76ea127f212f6a7bee134f6df2d1d21",
-                "sha256:1afbac344aa68c29e81ab56c1a9411c3663157b5aee5065b7fa030b398d4f7e0",
-                "sha256:1baad9d073692421ad5dbbd81430aba6c7f5fdc347f03537ae046ddf2c9b2297",
-                "sha256:1d8736421a2358becd3edf20260e41a06a0bf08a560480d3a5734a6bcbacf591",
-                "sha256:1e1d9bddc5afaddf0de76246d3f2152f961697ad7439c559f179002682c45801",
-                "sha256:1f179dc8b2643715f020f4d119d5529b02cd794c1c8f305868b73b8674d2a03f",
-                "sha256:241fb7bdf97cb1df1edfa8f0bcdfd80525d4023dac4523a241907c8b2f44e541",
-                "sha256:2f9765ee5acd3dbdcdc0d0c79309e01f7c16bc8d39b49250bf88de7b46daaf58",
-                "sha256:312e1e1b1c3ce0c67e0b8105317323e12807955e8186872affb667dbd67971f6",
-                "sha256:3273db1a8055ca70257fd3691c6d2c216544e1a70b673543e15cc077d8e9c730",
-                "sha256:34dfaa8c02891f9a246b17a732ca3e99c5e42802416628e740a5d1cb2f50ff49",
-                "sha256:3aa3f5288af349a0f3a96448ebf2e57e17332d99f4f30b02093b7948bd9f94cc",
-                "sha256:51102e160b9d83c1cc435162d90b8e3c8c93b28d18d87b60c56522d332d26879",
-                "sha256:56115fc2e2a4140e8994eb9585119a1ae9223b506826089a3ba753a62bd194a6",
-                "sha256:69d83de14dbe8fe51dccfd36f88bf0b40f5debeac763edf9f8325180190eba6e",
-                "sha256:99fdce94aeaa3ccbdfcb1e23b34273605c5853aa92ec23d84c84765178662c6c",
-                "sha256:a7c0cd5b8a20f3093ee4a67374ccb3b8a126743b15a4d759e2a1bf098faac2b2",
-                "sha256:abe12886554634ed95416a46701a917784cb2b4c77bfacac6916681d49bbf83d",
-                "sha256:b4f67b5183bd5f9bafaeb76ad119e977ba570d2b0e61202f534ac9b5c33b4485",
-                "sha256:bdd7c1658475cc1b867b36d5c4ed4bc316be8d3368abe03d348ba906a1f83b0e",
-                "sha256:c6f24149a19f611a415a51b9bc5f17b6c2f698e0d6b41ffb3fa9f24d35d05d73",
-                "sha256:d1e111b3ab98613115a208c1017f266478b0ab224a67bc8eac670fa0bad7d488",
-                "sha256:d6520aa965773bbab6cb7a791d5895b00d02cf9adc93ac2bf4edb9ac1a6addc5",
-                "sha256:dd185cde2ccad7b649593b0cda72021bc8a91667417001dbaf24cd746ecb7c11",
-                "sha256:de2e5b0828a9d285f909b5d2e9d43f1cf6cf21fe65bc7660bdaa1780c7b58298",
-                "sha256:f726444b8e909c4f41b4fde416e1071cf28fa84634bfb4befdf400933b6463af"
+                "sha256:0537eee4902e8bf4f41bfee8133f7edf96533dd175930a12086d6a40d62376b2",
+                "sha256:0562ec748abd230ab87d73384e08fa784f9b9cee89e28696087d2d22c052cc27",
+                "sha256:09e91831e749fbf0f24608694e4573be0ef51430229450c39c83176cc2e2d353",
+                "sha256:1ae4c0722fc70c0d4fba43ae33c2885f705e96dce1db41f75ae14a2d2749b428",
+                "sha256:1c630c083d782cbaf1f7f37f6cac87bda9cff643cf2803a5f180f30d97955cef",
+                "sha256:2fe74e3836bd8c0fa7467ffae05545233c7f37de1eb765cacfda15ad20c6574a",
+                "sha256:37af783c2667ead34a811037bda56a0b142ac8438f7ed29ae93f82ddb812fbd6",
+                "sha256:3f2d9eafbb0b24a33f56acd16f39fc935756524dcb3172892721c54713964c70",
+                "sha256:47d8365a8ef14097aa4c65730689be51851b4ade677285a3b2daa03b37893e26",
+                "sha256:510e904079bc56ea784677348e151e1156040dbfb736f1d8ea4b9e6d0ab2d9f4",
+                "sha256:58d0851da422bba31c7f652a7e9335313cf94a641aa6d73b8f3c67602f75b593",
+                "sha256:7940d5c2185ffb989203dacbb28e6ae88b4f1bb25d04e17f94b0edd82232bcbd",
+                "sha256:7cf39bb3a905579836f7a8f3a45320d9eb22f16ab0c1e112efb940ced4d057a5",
+                "sha256:9563a23c1456c0ab550c087833bc13fcc61013a66c6420921d5b70550ea312bf",
+                "sha256:95b392952935947e0786a90b75cc33388549dcb19af716b525dae65b186138fc",
+                "sha256:983129f3fd3cef5c3cf067adcca56e30a169656c00fcc6c648629dbb850b27fa",
+                "sha256:a0b75b1f1854771844c647c464533def3e0a899dd094a85d1d4ed72ecaaee93d",
+                "sha256:b5db89cc0ef624f3a81214b7961a99f443b8c91e88188376b6b322fd10d5b118",
+                "sha256:c0a7751ba1a4bfbe7831920d98cee3ce748007eab8dfda74593d44079568219a",
+                "sha256:c0c5a7d4aafcc30c9b6d8613a362567e32e5f5b708dc41bc3a81dac56f8af8bb",
+                "sha256:d4d63d85eacc6cb37b459b16061e1f100d154bee89dc8d8f9a6128a5a538e92e",
+                "sha256:da5e7e941d6e71c9c9a717c93725cda0708c2474f532e3680ac5e39ec57d224d",
+                "sha256:dccad2b3c583f036f43f80ac99ee212c2fa9a45151358d55f13004d095e683b2",
+                "sha256:df46307d39f2aeaafa1d25309b8a8d11738b73e9861f72d4d0a092528f498baa",
+                "sha256:e70b5e1cb48828ddd2818f99b1662cb9226dc6f57d07fc75485405c77da17436",
+                "sha256:ea825562b8cd057cbc9810d496b8b5dec37a1e2fc7b27bc7c1e72ce94462a09a"
             ],
-            "version": "==4.3.0"
+            "version": "==4.3.1"
         },
         "markupsafe": {
             "hashes": [
@@ -283,10 +279,10 @@
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:642afdabb681d39f5948fd5477764d94faf17ce40e5691e9998b52815fbb4e71",
-                "sha256:d14fcb29dabecba3d7b360bf72327c26c385248a5d603cf6be5f566ce999b261"
+                "sha256:79580acf813e3b7d6e69783884e6e83ac94bf4617b36a135b85c599d8a818a7b",
+                "sha256:a52090e8c5841ebbf08ae455146792d9ef3e8445b21055d3a3b7ed9c712b7c7c"
             ],
-            "version": "==0.2.3"
+            "version": "==0.2.4"
         },
         "pycparser": {
             "hashes": [
@@ -317,17 +313,17 @@
         },
         "pyrsistent": {
             "hashes": [
-                "sha256:5a3827d57ad3e46820e5ee4ed5b9e0ee7bc4686df6634a7368bc1863a5c48a77"
+                "sha256:07f7ae71291af8b0dbad8c2ab630d8223e4a8c4e10fc37badda158c02e753acf"
             ],
-            "version": "==0.14.9"
+            "version": "==0.14.10"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
             "index": "pypi",
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "pytz": {
             "hashes": [
@@ -361,11 +357,11 @@
         },
         "scrapy": {
             "hashes": [
-                "sha256:005933cc426b8ff7eae84ef8b9370f6465f9e43c4daede68474711b5e21fe607",
-                "sha256:c81e8ed141eb0ac0b0dcb13854c19c1faf84da53550a3d3d4c2326e671e90655"
+                "sha256:4ec03552c9aed1e82a376488150e904e0213bdee3ca140225105e9b03d0de204",
+                "sha256:558dfd10ac53cb324ecd7eefd3eac412161c7507c082b01b0bcd2c6e2e9f0766"
             ],
             "index": "pypi",
-            "version": "==1.5.2"
+            "version": "==1.6.0"
         },
         "scrapy-sentry": {
             "hashes": [
@@ -447,10 +443,10 @@
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
-                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
             ],
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [
@@ -459,13 +455,20 @@
             ],
             "version": "==18.2.0"
         },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
         "flake8": {
             "hashes": [
-                "sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670",
-                "sha256:c01f8a3963b3571a8e6bd7a4063359aff90749e160778e03817cd9b71c9e07d2"
+                "sha256:6d8c66a65635d46d54de59b027a1dda40abbe2275b3164b634835ac9c13fd048",
+                "sha256:6eab21c6e34df2c05416faa40d0c59963008fff29b6f0ccfe8fa28152ab3e383"
             ],
             "index": "pypi",
-            "version": "==3.6.0"
+            "version": "==3.7.6"
         },
         "freezegun": {
             "hashes": [
@@ -493,11 +496,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
-                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
-                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
+                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
             ],
-            "version": "==5.0.0"
+            "markers": "python_version > '2.7'",
+            "version": "==6.0.0"
         },
         "pluggy": {
             "hashes": [
@@ -515,33 +518,33 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
-                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
             ],
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
-                "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
+                "sha256:5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d",
+                "sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"
             ],
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:41568ea7ecb4a68d7f63837cf65b92ce8d0105e43196ff2b26622995bb3dc4b2",
-                "sha256:c3c573a29d7c9547fb90217ece8a8843aa0c1328a797e200290dc3d0b4b823be"
+                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
+                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
             ],
             "index": "pypi",
-            "version": "==4.1.1"
+            "version": "==4.3.0"
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
             "index": "pypi",
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "six": {
             "hashes": [
@@ -552,11 +555,11 @@
         },
         "yapf": {
             "hashes": [
-                "sha256:8aa7f9abdb97b4da4d3227306b88477982daafef0a96cc41639754ca31f46d55",
-                "sha256:f2df5891481f94ddadfbf8ae8ae499080752cfb06005a31bbb102f3012f8b944"
+                "sha256:edb47be90a56ca6f3075fe24f119a22225fbd62c66777b5d3916a7e9e793891b",
+                "sha256:f58069d5e0df60c078f3f986b8a63acfda73aa6ebb7cd423f6eabd1cb06420ba"
             ],
             "index": "pypi",
-            "version": "==0.25.0"
+            "version": "==0.26.0"
         }
     }
 }

--- a/city_scrapers/spiders/chi_animal.py
+++ b/city_scrapers/spiders/chi_animal.py
@@ -1,90 +1,48 @@
-# -*- coding: utf-8 -*-
-"""
-All spiders should yield data shaped according to the Open Civic Data
-specification (http://docs.opencivicdata.org/en/latest/data/event.html).
-"""
-import datetime
+from datetime import timedelta
 
+from city_scrapers_core.constants import ADVISORY_COMMITTEE
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
 from dateutil.parser import parse as dateparse
 
-from city_scrapers.constants import ADVISORY_COMMITTEE
-from city_scrapers.spider import Spider
 
-
-class ChiAnimalSpider(Spider):
+class ChiAnimalSpider(CityScrapersSpider):
     name = 'chi_animal'
-    agency_name = 'Chicago Animal Care and Control'
+    agency = 'Chicago Animal Care and Control'
     timezone = 'America/Chicago'
-    allowed_domains = ['www.cityofchicago.org']
-    start_urls = ['https://www.cityofchicago.org/city/en/depts/cacc/supp_info/public_notice.html']
+    allowed_domains = ['www.chicago.gov']
+    start_urls = ['https://www.chicago.gov/city/en/depts/cacc/supp_info/public_notice.html']
 
     def parse(self, response):
         """
-        `parse` should always `yield` a dict that follows the `Open Civic Data
-        event standard <http://docs.opencivicdata.org/en/latest/data/event.html>`_.
+        `parse` should always `yield` Meeting items.
 
-        Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
         needs.
         """
-        for item in response.css('.page-full-description').css("ul").css("li"):
-            # Pull the string
+        for item in response.css('.page-full-description ul li'):
+            start_str = ''.join(item.xpath('.//text()').extract()).strip()
             try:
-                text = item.xpath("text()").extract()[0]
-            except IndexError:
+                start_dt = dateparse(start_str)
+            except ValueError:
                 continue
 
-            # Strip it
-            text = text.strip()
-
-            # Pass if there's nothing left
-            if not text:
-                continue
-
-            # Parse the item
-            data = {
-                '_type': 'event',
-                'name': 'Advisory Board',
-                'event_description': '',
-                'classification': ADVISORY_COMMITTEE,
-                'start': self._parse_start(text),
-                'all_day': False,
-                'location': {
+            meeting = Meeting(
+                title='Advisory Board',
+                description='',
+                classification=ADVISORY_COMMITTEE,
+                start=start_dt,
+                end=start_dt + timedelta(hours=3),
+                time_notes='Estimated 3 hour duration',
+                all_day=False,
+                location={
                     'name': 'David R. Lee Animal Care Center',
                     'address': '2741 S. Western Ave, Chicago, IL 60608',
                 },
-                'sources': self._parse_sources(response),
-                'documents': [],
-            }
-            data['id'] = self._generate_id(data)
-            data['end'] = self._generate_end(data['start'])
-            data['status'] = self._generate_status(data, text=text)
+                links=[],
+                source=response.url,
+            )
+            meeting['id'] = self._get_id(meeting)
+            meeting['status'] = self._get_status(meeting, text=start_str)
 
-            yield data
-
-    def _parse_start(self, item):
-        """
-        Parse start date and time.
-        """
-        dt = dateparse(item)
-        return {
-            'date': dt.date(),
-            'time': dt.time(),
-        }
-
-    def _generate_end(self, start):
-        """
-        Estimate end date and time.
-        """
-        start_dt = datetime.datetime.combine(start['date'], start['time'])
-        end_dt = start_dt + datetime.timedelta(hours=3)
-        return {
-            'date': end_dt.date(),
-            'time': end_dt.time(),
-            'note': 'estimated 3 hours after the start time',
-        }
-
-    def _parse_sources(self, response):
-        """
-        Parse sources.
-        """
-        return [{'url': response.url, 'note': ''}]
+            yield meeting

--- a/city_scrapers/spiders/chi_low_income_housing_trust_fund.py
+++ b/city_scrapers/spiders/chi_low_income_housing_trust_fund.py
@@ -24,6 +24,10 @@ class ChiLowIncomeHousingTrustFundSpider(CityScrapersSpider):
         """
         items = self._parse_calendar(response)
         for item in items:
+            # Drop empty links
+            if 'http' not in item['source']:
+                continue
+
             req = scrapy.Request(
                 item['source'],
                 callback=self._parse_detail,
@@ -57,6 +61,7 @@ class ChiLowIncomeHousingTrustFundSpider(CityScrapersSpider):
                     classification=self._parse_classification(title),
                     all_day=False,
                     links=[],
+                    time_notes='',
                     source=self._parse_source(item, response.url),
                 )
             )

--- a/city_scrapers/spiders/mi_belle_isle.py
+++ b/city_scrapers/spiders/mi_belle_isle.py
@@ -1,63 +1,52 @@
-# -*- coding: utf-8 -*-
 import re
+from datetime import datetime
 from urllib.parse import urljoin
 
+from city_scrapers_core.constants import ADVISORY_COMMITTEE
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
 from dateutil.parser import parse as dateparse
 
-from city_scrapers.constants import ADVISORY_COMMITTEE
-from city_scrapers.spider import Spider
 
-
-class MiBelleIsleSpider(Spider):
+class MiBelleIsleSpider(CityScrapersSpider):
     name = 'mi_belle_isle'
-    agency_name = 'Michigan Belle Isle Advisory Committee'
+    agency = 'Michigan Belle Isle Advisory Committee'
     timezone = 'America/Detroit'
     allowed_domains = ['www.michigan.gov']
     start_urls = ['https://www.michigan.gov/dnr/0,4570,7-350-79137_79763_79901---,00.html']
 
     def parse(self, response):
         """
-        `parse` should always `yield` a dict that follows the Event Schema
-        <https://city-bureau.github.io/city-scrapers/06_event_schema.html>.
+        `parse` should always `yield` Meeting items.
 
-        Change the `_parse_id`, `_parse_name`, etc methods to fit your scraping
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
         needs.
         """
         for item in response.xpath('//tbody/tr'):
             # Adapted the combined start and end from chi_city_college
-            date, start_time, end_time = self._parse_date_and_times(item)
-            data = {
-                '_type': 'event',
-                'name': 'Belle Isle Advisory Committee',
-                'event_description': '',
-                'classification': ADVISORY_COMMITTEE,
-                'start': {
-                    'date': date,
-                    'time': start_time,
-                    'note': '',
-                },
-                'end': {
-                    'date': date,
-                    'time': end_time,
-                    'note': '',
-                },
-                'all_day': False,
-                'location': self._parse_location(item),
-                'documents': self._match_documents(item, response),
-                'sources': [{
-                    'url': response.url,
-                    'note': ''
-                }],
-            }
+            start, end = self._parse_start_end(item)
+            meeting = Meeting(
+                title='Belle Isle Advisory Committee',
+                description='',
+                classification=ADVISORY_COMMITTEE,
+                start=start,
+                end=end,
+                time_notes='',
+                all_day=False,
+                location=self._parse_location(item),
+                links=self._match_links(item, start, response),
+                source=response.url,
+            )
 
-            data['status'] = self._generate_status(data)
-            data['id'] = self._generate_id(data)
+            status_text = ''.join(item.xpath('.//td[3]//text()').extract())
+            meeting['status'] = self._get_status(meeting, text=status_text)
+            meeting['id'] = self._get_id(meeting)
 
-            yield data
+            yield meeting
 
-    def _parse_date_and_times(self, item):
+    def _parse_start_end(self, item):
         """
-        Parse start and end date and times.
+        Parse start and end datetimes.
         """
         date_str = re.sub(r'[^a-zA-Z,\d\s]', '', item.css('td:first-child *::text').extract_first())
         time_str = re.sub(
@@ -73,18 +62,17 @@ class MiBelleIsleSpider(Spider):
         start_value = dateparse('{} {} {}'.format(date_str, time_start_str, meridian_str))
         end_value = dateparse('{} {} {}'.format(date_str, time_end_str, meridian_str))
 
-        return date_value.date(), start_value.time(), end_value.time()
+        return (
+            datetime.combine(date_value.date(), start_value.time()),
+            datetime.combine(date_value.date(), end_value.time()),
+        )
 
     def _parse_location(self, item):
-        """
-        Parse or generate location. Latitude and longitude can be
-        left blank and will be geocoded later.
-        """
+        """Parse or generate location."""
         location_name = item.xpath('.//td[3]/text()').extract_first()
         DEFAULT_LOCATION = {
             'name': 'Belle Isle',
             'address': 'Belle Isle, Detroit, MI 48207',
-            'neighborhood': '',
         }
         if location_name is None:
             return DEFAULT_LOCATION
@@ -100,18 +88,16 @@ class MiBelleIsleSpider(Spider):
         return {
             'name': location_name,
             'address': location_address,
-            'neighborhood': '',
         }
 
-    def _parse_documents(self, response):
-        """
-        Get documents from separate agendas and minutes lists.
-        """
+    def _parse_links(self, response):
+        """Get links for separate agendas and minutes lists."""
         agendas_dict = {}
         minutes_dict = {}
         for agendasItem in response.xpath('//div[contains(@id, "comp_101140")]//a'):
             link_href = agendasItem.xpath('./@href').extract_first()
             link_text = agendasItem.xpath('./text()').extract_first().replace(' (draft)', '')
+            link_text = link_text.split(' - ')[0]
             agendas_dict[dateparse(link_text).date()] = link_href
 
         for minutesItem in response.xpath('//div[contains(@id, "comp_101141")]//a'):
@@ -121,20 +107,18 @@ class MiBelleIsleSpider(Spider):
 
         return agendas_dict, minutes_dict
 
-    def _match_documents(self, item, response):
-        """
-        Match up the documents with the date to which they belong
-        """
-        matched_docs = []
-        meeting_date, *_ = self._parse_date_and_times(item)
-        meeting_agendas, meeting_minutes = self._parse_documents(response)
+    def _match_links(self, item, start, response):
+        """Match up the links with the date to which they belong"""
+        matched_links = []
+        meeting_date = start.date()
+        meeting_agendas, meeting_minutes = self._parse_links(response)
 
         if meeting_date in meeting_agendas:
             agenda_url = meeting_agendas[meeting_date]
-            matched_docs.append({'url': urljoin(response.url, agenda_url), 'note': 'Agenda'})
+            matched_links.append({'href': urljoin(response.url, agenda_url), 'title': 'Agenda'})
 
         if meeting_date in meeting_minutes:
             minutes_url = meeting_minutes[meeting_date]
-            matched_docs.append({'url': urljoin(response.url, minutes_url), 'note': 'Minutes'})
+            matched_links.append({'href': urljoin(response.url, minutes_url), 'title': 'Minutes'})
 
-        return matched_docs
+        return matched_links

--- a/tests/test_chi_animal.py
+++ b/tests/test_chi_animal.py
@@ -1,7 +1,9 @@
+from datetime import datetime
+
 import pytest
+from city_scrapers_core.constants import ADVISORY_COMMITTEE, PASSED
 from tests.utils import file_response
 
-from city_scrapers.constants import ADVISORY_COMMITTEE
 from city_scrapers.spiders.chi_animal import ChiAnimalSpider
 
 test_response = file_response(
@@ -9,37 +11,27 @@ test_response = file_response(
     url='https://www.cityofchicago.org/city/en/depts/cacc/supp_info/public_notice.html'
 )
 spider = ChiAnimalSpider()
-parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
+parsed_items = [item for item in spider.parse(test_response)]
 
 
 def test_len():
     assert len(parsed_items) == 3
 
 
-# Different that last static pull
-# def test_id():
-#    assert parsed_items[0]['id'] == 'chi_animal/201709210000/x/commission_meeting'
+def test_start():
+    assert parsed_items[0]['start'] == datetime(2017, 9, 21)
 
 
-# Different than last static pull
-def test_start_time():
-    assert parsed_items[0]['start']['date'].isoformat() == '2017-09-21'
-    assert parsed_items[0]['start']['time'].isoformat() == '00:00:00'
+def test_end():
+    assert parsed_items[0]['end'] == datetime(2017, 9, 21, 3)
 
 
-def test_end_time():
-    assert parsed_items[0]['end']['date'].isoformat() == '2017-09-21'
-    assert parsed_items[0]['end']['time'].isoformat() == '03:00:00'
-    assert parsed_items[0]['end']['note'] == ('estimated 3 hours after the start time')
+def test_time_notes():
+    assert parsed_items[0]['time_notes'] == 'Estimated 3 hour duration'
 
 
 @pytest.mark.parametrize('item', parsed_items)
-def test_type(item):
-    assert item['_type'] == 'event'
-
-
-@pytest.mark.parametrize('item', parsed_items)
-def test_allday(item):
+def test_all_day(item):
     assert item['all_day'] is False
 
 
@@ -49,13 +41,13 @@ def test_class(item):
 
 
 @pytest.mark.parametrize('item', parsed_items)
-def test_name(item):
-    assert item['name'] == 'Advisory Board'
+def test_title(item):
+    assert item['title'] == 'Advisory Board'
 
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_description(item):
-    assert 'description' not in item
+    assert item['description'] == ''
 
 
 @pytest.mark.parametrize('item', parsed_items)
@@ -68,17 +60,15 @@ def test_location(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_status(item):
-    assert item['status'] == 'passed'
+    assert item['status'] == PASSED
 
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_sources(item):
-    assert item['sources'] == [{
-        'url': 'https://www.cityofchicago.org/city/en/depts/cacc/supp_info/public_notice.html',
-        'note': ''
-    }]
+    assert item['source'
+                ] == 'https://www.cityofchicago.org/city/en/depts/cacc/supp_info/public_notice.html'
 
 
 @pytest.mark.parametrize('item', parsed_items)
-def test_documents(item):
-    assert len(item['documents']) == 0
+def test_links(item):
+    assert len(item['links']) == 0

--- a/tests/test_cook_water.py
+++ b/tests/test_cook_water.py
@@ -85,7 +85,7 @@ def test_description(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_type(item):
-    assert item['_type'] is 'event'
+    assert item['_type'] == 'event'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_det_eight_mile_woodward_corridor_improvement_authority.py
+++ b/tests/test_det_eight_mile_woodward_corridor_improvement_authority.py
@@ -77,7 +77,7 @@ def test_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_classification(item):
-    assert item['classification'] is 'Board'
+    assert item['classification'] == 'Board'
 
 
 @pytest.mark.parametrize('item', parsed_items)
@@ -167,7 +167,7 @@ def test_prev_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_prev_items)
 def test_prev_classification(item):
-    assert item['classification'] is 'Board'
+    assert item['classification'] == 'Board'
 
 
 @pytest.mark.parametrize('item', parsed_prev_items)

--- a/tests/test_det_entertainment_commission.py
+++ b/tests/test_det_entertainment_commission.py
@@ -64,7 +64,7 @@ def test_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_classification(item):
-    assert item['classification'] is 'Commission'
+    assert item['classification'] == 'Commission'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_det_library_commission.py
+++ b/tests/test_det_library_commission.py
@@ -82,7 +82,7 @@ def test_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_classification(item):
-    assert item['classification'] is 'Commission'
+    assert item['classification'] == 'Commission'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_det_local_development_finance_authority.py
+++ b/tests/test_det_local_development_finance_authority.py
@@ -181,7 +181,7 @@ def test_prev_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_prev_items)
 def test_prev_classification(item):
-    assert item['classification'] is 'Board'
+    assert item['classification'] == 'Board'
 
 
 @pytest.mark.parametrize('item', parsed_prev_items)

--- a/tests/test_det_next_michigan_development_corporation.py
+++ b/tests/test_det_next_michigan_development_corporation.py
@@ -175,7 +175,7 @@ def test_prev_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_prev_items)
 def test_prev_classification(item):
-    assert item['classification'] is 'Board'
+    assert item['classification'] == 'Board'
 
 
 @pytest.mark.parametrize('item', parsed_prev_items)

--- a/tests/test_det_wrecking_examiners.py
+++ b/tests/test_det_wrecking_examiners.py
@@ -69,7 +69,7 @@ def test_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_classification(item):
-    assert item['classification'] is 'Board'
+    assert item['classification'] == 'Board'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_det_zoning_appeals.py
+++ b/tests/test_det_zoning_appeals.py
@@ -73,7 +73,7 @@ def test_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_classification(item):
-    assert item['classification'] is 'Board'
+    assert item['classification'] == 'Board'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_mi_belle_isle.py
+++ b/tests/test_mi_belle_isle.py
@@ -1,9 +1,9 @@
-from datetime import date, time
+from datetime import datetime
 
 import pytest
+from city_scrapers_core.constants import ADVISORY_COMMITTEE, PASSED
 from tests.utils import file_response
 
-from city_scrapers.constants import ADVISORY_COMMITTEE, PASSED
 from city_scrapers.spiders.mi_belle_isle import MiBelleIsleSpider
 
 test_response = file_response(
@@ -11,28 +11,28 @@ test_response = file_response(
     'https://www.michigan.gov/dnr/0,4570,7-350-79137_79763_79901---,00.html',
 )
 spider = MiBelleIsleSpider()
-parsed_items = [item for item in spider.parse(test_response) if isinstance(item, dict)]
-parsed_items = sorted(parsed_items, key=lambda x: (x['start']['date'], x['start']['time']))
+parsed_items = [item for item in spider.parse(test_response)]
+parsed_items = sorted(parsed_items, key=lambda x: x['start'])
 
 
-def test_name():
-    assert parsed_items[0]['name'] == 'Belle Isle Advisory Committee'
+def test_title():
+    assert parsed_items[0]['title'] == 'Belle Isle Advisory Committee'
 
 
 def test_description():
-    assert parsed_items[0]['event_description'] == ''
+    assert parsed_items[0]['description'] == ''
 
 
 def test_start():
-    assert parsed_items[0]['start'] == {'date': date(2018, 1, 18), 'time': time(9, 0), 'note': ''}
+    assert parsed_items[0]['start'] == datetime(2018, 1, 18, 9)
 
 
 def test_end():
-    assert parsed_items[0]['end'] == {'date': date(2018, 1, 18), 'time': time(11, 0), 'note': ''}
+    assert parsed_items[0]['end'] == datetime(2018, 1, 18, 11)
 
 
 def test_id():
-    assert parsed_items[0]['id'] == ('mi_belle_isle/201801180900/x/belle_isle_advisory_committee')
+    assert parsed_items[0]['id'] == 'mi_belle_isle/201801180900/x/belle_isle_advisory_committee'
 
 
 def test_status():
@@ -41,7 +41,6 @@ def test_status():
 
 def test_location():
     assert parsed_items[0]['location'] == {
-        'neighborhood': '',
         'name': 'Flynn Pavilion',
         'address': ('Intersection of Picnic Way and Loiter Way, '
                     'Belle Isle, Detroit, MI 48207'),
@@ -49,18 +48,15 @@ def test_location():
 
 
 def test_sources():
-    assert parsed_items[0]['sources'] == [{
-        'url': ('https://www.michigan.gov/dnr/'
-                '0,4570,7-350-79137_79763_79901---,00.html'),
-        'note': ''
-    }]
+    assert parsed_items[0][
+        'source'] == 'https://www.michigan.gov/dnr/0,4570,7-350-79137_79763_79901---,00.html'
 
 
-def test_documents():
-    assert parsed_items[0]['documents'] == [{
-        'note': 'Minutes',
-        'url': ('https://www.michigan.gov/documents/'
-                'dnr/BIPAC011818minutes_612208_7.pdf'),
+def test_links():
+    assert parsed_items[0]['links'] == [{
+        'title': 'Minutes',
+        'href': ('https://www.michigan.gov/documents/'
+                 'dnr/BIPAC011818minutes_612208_7.pdf'),
     }]
 
 
@@ -72,8 +68,3 @@ def test_all_day(item):
 @pytest.mark.parametrize('item', parsed_items)
 def test_classification(item):
     assert item['classification'] == ADVISORY_COMMITTEE
-
-
-@pytest.mark.parametrize('item', parsed_items)
-def test__type(item):
-    assert parsed_items[0]['_type'] == 'event'

--- a/tests/test_wayne_election_commission.py
+++ b/tests/test_wayne_election_commission.py
@@ -80,7 +80,7 @@ def test_all_day(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_classification(item):
-    assert item['classification'] is 'Commission'
+    assert item['classification'] == 'Commission'
 
 
 @pytest.mark.parametrize('item', parsed_items)


### PR DESCRIPTION
- Updates `city-scrapers-core` to 0.2.2
- Fixes `chi_animal` and `mi_belle_isle` and updates them to use `Meeting` items
- Fixes an issue in `chi_low_income_housing_trust_fund` where it was attempting to scrape empty URLs