### PR TITLE
Add travis_wait to runall script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_deploy:
 deploy:
   - skip_cleanup: true
     provider: script
-    script: scrapy runall -s LOG_ENABLED=False
+    script: travis_wait 30 scrapy runall -s LOG_ENABLED=False
     on:
       python: 3.6
       branch: master


### PR DESCRIPTION
We aren't logging anything anymore since even a small amount of logs would go over the Travis limits with all the pages we're scraping, but because of this we're hitting Travis's output-based timeout.

This adds `travis_wait` to the `scrapy runall` command as the [recommended way to get around this issue](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received)