### PR TITLE
Fix Travis CI deploy timeout

### DIFF
--- a/.deploy.sh
+++ b/.deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+scrapy runall -s LOG_ENABLED=False &
+
+# Output to the screen every 9 minutes to prevent a travis timeout
+# https://stackoverflow.com/a/40800348
+export PID=$!
+while [[ `ps -p $PID | tail -n +2` ]]; do
+  echo 'Deploying'
+  sleep 540
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_deploy:
 deploy:
   - skip_cleanup: true
     provider: script
-    script: travis_wait 30 scrapy runall -s LOG_ENABLED=False
+    script: ./.deploy.sh
     on:
       python: 3.6
       branch: master


### PR DESCRIPTION
It looks like `travis_wait` isn't supported in the `deploy` step, so using a custom script instead