### PR TITLE
[Docs] Change yapf flag to what Travis runs

### DIFF
--- a/docs/_docs/04-development.md
+++ b/docs/_docs/04-development.md
@@ -211,7 +211,7 @@ We use [`flake8`](http://flake8.pycqa.org/en/latest/){:target="\_blank"}, [`isor
 ```bash
 $ flake8
 $ isort
-$ yapf --in-place --recursive ./city_scrapers/ ./tests/
+$ yapf --diff --recursive ./city_scrapers/ ./tests/
 ```
 
 Most text editors can be configured to fix style issues for you based off of the configuration settings in `setup.cfg`. Here's an example for VSCode using the [standard Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python){:target="\_blank"} (which can be modified/added at `.vscode/settings.json` in your project directory):


### PR DESCRIPTION
`yapf --in-place --recursive ./city_scrapers/ ./tests/` caused Travis to fail as seen in the attached screenshot.

Proposing a change in the documentation to what Travis runs (`yapf --diff --recursive ./city_scrapers/ ./tests/`) so a user can make the appropriate changes.