### PR TITLE
Update redirecting URLs

### DIFF
--- a/city_scrapers/spiders/chi_buildings.py
+++ b/city_scrapers/spiders/chi_buildings.py
@@ -12,7 +12,7 @@ class ChiBuildingsSpider(CityScrapersSpider):
     name = 'chi_buildings'
     agency = 'Public Building Commission of Chicago'
     allowed_domains = ['www.pbcchicago.com']
-    base_url = 'http://www.pbcchicago.com/wp-admin/admin-ajax.php?action=eventorganiser-fullcal'
+    base_url = 'https://www.pbcchicago.com/wp-admin/admin-ajax.php?action=eventorganiser-fullcal'
     timezone = 'America/Chicago'
     start_urls = [
         '{}&start={}&end={}'.format(

--- a/city_scrapers/spiders/chi_community_development.py
+++ b/city_scrapers/spiders/chi_community_development.py
@@ -11,9 +11,9 @@ class ChiCommunityDevelopmentSpider(CityScrapersSpider):
     name = 'chi_community_development'
     agency = 'Chicago Department of Planning and Development'
     timezone = 'America/Chicago'
-    allowed_domains = ['www.cityofchicago.org']
+    allowed_domains = ['chicago.gov']
     start_urls = [
-        'https://www.cityofchicago.org/city/en/depts/dcd/supp_info/'
+        'https://chicago.gov/city/en/depts/dcd/supp_info/'
         'community_developmentcommission.html'
     ]
 

--- a/city_scrapers/spiders/chi_low_income_housing_trust_fund.py
+++ b/city_scrapers/spiders/chi_low_income_housing_trust_fund.py
@@ -13,7 +13,6 @@ class ChiLowIncomeHousingTrustFundSpider(CityScrapersSpider):
     timezone = 'America/Chicago'
     allowed_domains = ['www.chicagotrustfund.org']
     start_urls = ['http://www.chicagotrustfund.org/about-us/upcomingevents/']
-    custom_settings = {'ROBOTSTXT_OBEY': False}
 
     def parse(self, response):
         """

--- a/city_scrapers/spiders/chi_plan_commission.py
+++ b/city_scrapers/spiders/chi_plan_commission.py
@@ -11,10 +11,8 @@ class ChiPlanCommissionSpider(CityScrapersSpider):
     name = 'chi_plan_commission'
     agency = 'Chicago Department of Planning and Development'
     timezone = 'America/Chicago'
-    allowed_domains = ['www.cityofchicago.org']
-    start_urls = [
-        'https://www.cityofchicago.org/city/en/depts/dcd/supp_info/chicago_plan_commission.html'
-    ]
+    allowed_domains = ['chicago.gov']
+    start_urls = ['https://chicago.gov/city/en/depts/dcd/supp_info/chicago_plan_commission.html']
 
     def parse(self, response):
         """

--- a/city_scrapers/spiders/chi_policeboard.py
+++ b/city_scrapers/spiders/chi_policeboard.py
@@ -10,8 +10,8 @@ class ChiPoliceBoardSpider(CityScrapersSpider):
     name = 'chi_policeboard'
     timezone = 'America/Chicago'
     agency = 'Chicago Police Board'
-    allowed_domains = ['www.cityofchicago.org']
-    start_urls = ['http://www.cityofchicago.org/city/en/depts/cpb/provdrs/public_meetings.html']
+    allowed_domains = ['chicago.gov']
+    start_urls = ['http://chicago.gov/city/en/depts/cpb/provdrs/public_meetings.html']
 
     def parse(self, response):
         """

--- a/city_scrapers/spiders/il_metra_board.py
+++ b/city_scrapers/spiders/il_metra_board.py
@@ -10,7 +10,7 @@ class IlMetraBoardSpider(CityScrapersSpider):
     name = 'il_metra_board'
     agency = 'Illinois Metra'
     timezone = 'America/Chicago'
-    allowed_domains = ['metrarail.com']
+    allowed_domains = ['metrarail.com', 'metrarr.granicus.com']
     start_urls = ['https://metrarr.granicus.com/ViewPublisher.php?view_id=5']
     custom_settings = {'ROBOTSTXT_OBEY': False}
     location = {

--- a/tests/test_chi_animal.py
+++ b/tests/test_chi_animal.py
@@ -8,7 +8,7 @@ from city_scrapers.spiders.chi_animal import ChiAnimalSpider
 
 test_response = file_response(
     'files/chi_animal.html',
-    url='https://www.cityofchicago.org/city/en/depts/cacc/supp_info/public_notice.html'
+    url='https://chicago.gov/city/en/depts/cacc/supp_info/public_notice.html'
 )
 spider = ChiAnimalSpider()
 parsed_items = [item for item in spider.parse(test_response)]
@@ -65,8 +65,7 @@ def test_status(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_sources(item):
-    assert item['source'
-                ] == 'https://www.cityofchicago.org/city/en/depts/cacc/supp_info/public_notice.html'
+    assert item['source'] == 'https://chicago.gov/city/en/depts/cacc/supp_info/public_notice.html'
 
 
 @pytest.mark.parametrize('item', parsed_items)

--- a/tests/test_chi_plan_commission.py
+++ b/tests/test_chi_plan_commission.py
@@ -8,7 +8,7 @@ from city_scrapers.spiders.chi_plan_commission import ChiPlanCommissionSpider
 
 test_response = file_response(
     'files/chi_plan_commission_chicago_plan_commission.html',
-    'https://www.cityofchicago.org/city/en/depts/dcd/supp_info/chicago_plan_commission.html'
+    'https://chicago.gov/city/en/depts/dcd/supp_info/chicago_plan_commission.html'
 )
 spider = ChiPlanCommissionSpider()
 parsed_items = [item for item in spider.parse(test_response)]
@@ -57,19 +57,19 @@ def test_location():
 def test_source():
     assert parsed_items[0][
         'source'
-    ] == 'https://www.cityofchicago.org/city/en/depts/dcd/supp_info/chicago_plan_commission.html'  # noqa
+    ] == 'https://chicago.gov/city/en/depts/dcd/supp_info/chicago_plan_commission.html'  # noqa
 
 
 def test_links():
     assert parsed_items[0]['links'] == [
         {
             'href':
-                'https://www.cityofchicago.org/content/dam/city/depts/zlup/Planning_and_Policy/Minutes/CPC_Jan_2018_Minutes.pdf',  # noqa
+                'https://chicago.gov/content/dam/city/depts/zlup/Planning_and_Policy/Minutes/CPC_Jan_2018_Minutes.pdf',  # noqa
             'title': 'Minutes'
         },
         {
             'href':
-                'https://www.cityofchicago.org/content/dam/city/depts/zlup/Planning_and_Policy/Agendas/CPC_Jan_2018_Map_rev.pdf',  # noqa
+                'https://chicago.gov/content/dam/city/depts/zlup/Planning_and_Policy/Agendas/CPC_Jan_2018_Map_rev.pdf',  # noqa
             'title': 'Map'
         }
     ]

--- a/tests/test_chi_policeboard.py
+++ b/tests/test_chi_policeboard.py
@@ -8,7 +8,7 @@ from city_scrapers.spiders.chi_policeboard import ChiPoliceBoardSpider
 
 test_response = file_response(
     'files/chi_policeboard_public_meetings.html',
-    url='https://www.cityofchicago.org/city/en/depts/cpb/provdrs/public_meetings.html'
+    url='https://chicago.gov/city/en/depts/cpb/provdrs/public_meetings.html'
 )
 spider = ChiPoliceBoardSpider()
 parsed_items = [item for item in spider.parse(test_response)]
@@ -31,12 +31,12 @@ def test_links():
     assert parsed_items[8]['links'] == [
         {
             'href':
-                'https://www.cityofchicago.org/content/dam/city/depts/cpb/PubMtgMinutes/BlueBook09182017.pdf',  # noqa
+                'https://chicago.gov/content/dam/city/depts/cpb/PubMtgMinutes/BlueBook09182017.pdf',  # noqa
             'title': 'Blue Book'
         },
         {
             'href':
-                'https://www.cityofchicago.org/content/dam/city/depts/cpb/PubMtgMinutes/PubMtgTranscript09182017.pdf',  # noqa
+                'https://chicago.gov/content/dam/city/depts/cpb/PubMtgMinutes/PubMtgTranscript09182017.pdf',  # noqa
             'title': 'Transcript'
         },
     ]
@@ -75,5 +75,4 @@ def test_location(item):
 
 @pytest.mark.parametrize('item', parsed_items)
 def test_source(item):
-    assert item['source'
-                ] == 'https://www.cityofchicago.org/city/en/depts/cpb/provdrs/public_meetings.html'
+    assert item['source'] == 'https://chicago.gov/city/en/depts/cpb/provdrs/public_meetings.html'


### PR DESCRIPTION
Mostly updates any cityofchicago.org URLs to be chicago.gov and removes an unneeded robots.txt override