### PR TITLE
Adding link to technical guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## 1. Create a new issue to ask onboarding questions.
 
-We want the technical aspects of the project to be accessible to newcomers. As you're working through the set-up and installation, please create issues for roadblocks you encounter or anything that's confusing in the documentation. We're committed to helping you resolve these and improving the onboarding experience.  
+We want the technical aspects of the project to be accessible to newcomers. As you're working through the set-up and installation, please create issues for roadblocks you encounter or anything that's confusing in the documentation. We're committed to helping you resolve these and improving the onboarding experience. For more information about developing a spider, there is additional documentation [here](https://cityscrapers.org/docs/development/#contribute).
 
 ## 2. Open a Pull Request to talk about code and show us how things are going.
 


### PR DESCRIPTION
Hello!
I'm a new comer interested in working on this project. As I was looking around at how to get started, I noticed that it appeared that each of the scrapers was built from an initial template file. I couldn't find any information about creating a new scraper in CONTRIBUTING.md, which was frustrating. It wasn't until I saw this [link](https://cityscrapers.org/docs/development/#contribute) to the contribution guide that I was able see the steps for creating a new scraper from template. I'm not sure how it would fit in with the current CONTRIBUTING.md file, but it might be nice if these steps or a link to this guide could be included. 

Thanks