### PR TITLE
0627 spider chi ohare noise

### DIFF
--- a/city_scrapers/settings/base.py
+++ b/city_scrapers/settings/base.py
@@ -24,6 +24,9 @@ ROBOTSTXT_OBEY = True
 # Disable cookies (enabled by default)
 COOKIES_ENABLED = False
 
+LOG_LEVEL='ERROR'
+LOG_ENABLED=True
+
 # Throttle results by default
 AUTOTHROTTLE_ENABLED = True
 AUTOTHROTTLE_START_DELAY = 0.5

--- a/city_scrapers/settings/base.py
+++ b/city_scrapers/settings/base.py
@@ -24,9 +24,6 @@ ROBOTSTXT_OBEY = True
 # Disable cookies (enabled by default)
 COOKIES_ENABLED = False
 
-LOG_LEVEL='ERROR'
-LOG_ENABLED=True
-
 # Throttle results by default
 AUTOTHROTTLE_ENABLED = True
 AUTOTHROTTLE_START_DELAY = 0.5

--- a/city_scrapers/spiders/chi_ohare_noise.py
+++ b/city_scrapers/spiders/chi_ohare_noise.py
@@ -1,9 +1,10 @@
+import datetime
+
+import requests
 from city_scrapers_core import constants
 from city_scrapers_core.items import Meeting
 from city_scrapers_core.spiders import CityScrapersSpider
 from scrapy.selector import Selector
-import requests
-import datetime
 
 
 class ChiOhareNoiseSpider(CityScrapersSpider):
@@ -16,7 +17,6 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
     start_urls = ["https://www.oharenoise.org/about-oncc/agendas-and-minutes"]
 
     def parse(self, response):
-
         """
         `parse` should always `yield` Meeting items.
         loops through agenda/minutes page and compiles all agenda and minutes pdfs to links
@@ -50,24 +50,21 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
         """
         curr_date = datetime.date.today()
         months_urls = [
-                datetime.date(
-                    month=self._delta_months(curr_date.month, -2),
-                    day=1,
-                    year=curr_date.year),
-                datetime.date(
-                    month=self._delta_months(curr_date.month, -1),
-                    day=1,
-                    year=curr_date.year),
-                curr_date,
-                datetime.date(
-                    month=self._delta_months(curr_date.month, 1),
-                    day=1,
-                    year=curr_date.year)
-                ]
+            datetime.date(
+                month=self._delta_months(curr_date.month, -2), day=1, year=curr_date.year
+            ),
+            datetime.date(
+                month=self._delta_months(curr_date.month, -1), day=1, year=curr_date.year
+            ), curr_date,
+            datetime.date(month=self._delta_months(curr_date.month, 1), day=1, year=curr_date.year)
+        ]
         for calendar_date in months_urls:
-            self._parse_calendar(requests.get(
+            self._parse_calendar(
+                requests.get(
                     url="https://www.oharenoise.org/about-oncc/oncc-meetings/month.calendar/" +
-                    calendar_date.strftime("%Y/%m/%d")))
+                    calendar_date.strftime("%Y/%m/%d")
+                )
+            )
 
     def _parse_calendar(self, body):
         """
@@ -105,13 +102,13 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
             meeting['status'] = self._get_status(meeting)
         else:
             meeting = Meeting(
-                    title=title,
-                    start=start,
-                    classification=classification,
-                    description=description,
-                    location=location,
-                    all_day=False
-                    )
+                title=title,
+                start=start,
+                classification=classification,
+                description=description,
+                location=location,
+                all_day=False
+            )
             meeting['status'] = self._get_status(meeting)
             self.meetings[dict_key] = meeting
 
@@ -211,5 +208,5 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
         handles add and subtracting from months
         """
         months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        new = (curr-1) + delta
+        new = (curr - 1) + delta
         return months[new % 12]

--- a/city_scrapers/spiders/chi_ohare_noise.py
+++ b/city_scrapers/spiders/chi_ohare_noise.py
@@ -49,7 +49,15 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
         else:
             event_days = response.selector.xpath(".//td[@class='cal_dayshasevents']")
             for item in event_days:
-                print(item)
+                date = item.xpath(".//a[@class='cal_daylink']//span[@class='listview']/text()").get().lstrip()
+                events = item.xpath(".//a[@class='cal_titlelink']")
+                for event in events:
+
+                    time = event.xpath(".//span/text()").get()
+                    name = event.xpath("text()").get()
+                    print(date)
+                    print(name.split()[0].isupper())
+                    print(time)
 
     def _parse_title(self, item):
         """Parse or generate meeting title."""

--- a/city_scrapers/spiders/chi_ohare_noise.py
+++ b/city_scrapers/spiders/chi_ohare_noise.py
@@ -1,0 +1,95 @@
+from city_scrapers_core.constants import NOT_CLASSIFIED
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+
+
+class ChiOhareNoiseSpider(CityScrapersSpider):
+    name = "chi_ohare_noise"
+    agency = "Chicago O'Hare Noise Compatibility Commission"
+    timezone = "America/Chicago"
+    allowed_domains = ["www.oharenoise.org"]
+    start_urls = ["https://www.oharenoise.org/about-oncc/agendas-and-minutes",
+                  "https://www.oharenoise.org/about-oncc/oncc-meetings/month.calendar/"]
+
+    def parse(self, response):
+        """
+        `parse` should always `yield` Meeting items.
+
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
+        needs.
+        """
+
+
+        if "agendas" in response.url:
+
+            table_rows = response.selector.xpath(".//tbody//tr")
+            for item in table_rows:
+                table_columns = item.xpath(".//td")
+                title = table_columns[1].xpath("./span/text()").get()
+                date = table_columns[2].xpath("./span/text()").get()
+                #print(title, date)
+                meeting = Meeting(
+                    # Meeting title will always be second column
+                    # title=self._parse_title(table_columns[1]),
+                    # description=self._parse_description(item),
+                    # classification=self._parse_classification(item),
+                    # start=self._parse_start(item),
+                    # end=self._parse_end(item),
+                    # all_day=self._parse_all_day(item),
+                    # time_notes=self._parse_time_notes(item),
+                    # location=self._parse_location(item),
+                    # links=self._parse_links(item),
+                    # source=self._parse_source(response),
+                )
+
+                # meeting["status"] = self._get_status(meeting)
+                # meeting["id"] = self._get_id(meeting)
+
+                # yield meeting
+        else:
+            event_days = response.selector.xpath(".//td[@class='cal_dayshasevents']")
+            for item in event_days:
+                print(item)
+
+    def _parse_title(self, item):
+        """Parse or generate meeting title."""
+        return ""
+
+    def _parse_description(self, item):
+        """Parse or generate meeting description."""
+        return ""
+
+    def _parse_classification(self, item):
+        """Parse or generate classification from allowed options."""
+        return NOT_CLASSIFIED
+
+    def _parse_start(self, item):
+        """Parse start datetime as a naive datetime object."""
+        return None
+
+    def _parse_end(self, item):
+        """Parse end datetime as a naive datetime object. Added by pipeline if None"""
+        return None
+
+    def _parse_time_notes(self, item):
+        """Parse any additional notes on the timing of the meeting"""
+        return ""
+
+    def _parse_all_day(self, item):
+        """Parse or generate all-day status. Defaults to False."""
+        return False
+
+    def _parse_location(self, item):
+        """Parse or generate location."""
+        return {
+            "address": "",
+            "name": "",
+        }
+
+    def _parse_links(self, item):
+        """Parse or generate links."""
+        return [{"href": "", "title": ""}]
+
+    def _parse_source(self, response):
+        """Parse or generate source."""
+        return response.url

--- a/city_scrapers/spiders/chi_ohare_noise.py
+++ b/city_scrapers/spiders/chi_ohare_noise.py
@@ -1,7 +1,8 @@
 from city_scrapers_core.constants import NOT_CLASSIFIED
 from city_scrapers_core.items import Meeting
 from city_scrapers_core.spiders import CityScrapersSpider
-
+import datetime
+import time
 
 class ChiOhareNoiseSpider(CityScrapersSpider):
     name = "chi_ohare_noise"
@@ -18,38 +19,30 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
         Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
         needs.
         """
-
-
         if "agendas" in response.url:
 
             table_rows = response.selector.xpath(".//tbody//tr")
             for item in table_rows:
-                table_columns = item.xpath(".//td")
-                title = table_columns[1].xpath("./span/text()").get()
-                date = table_columns[2].xpath("./span/text()").get()
-                #print(title, date)
+
                 meeting = Meeting(
                     # Meeting title will always be second column
-                    # title=self._parse_title(table_columns[1]),
-                    # description=self._parse_description(item),
-                    # classification=self._parse_classification(item),
-                    # start=self._parse_start(item),
-                    # end=self._parse_end(item),
-                    # all_day=self._parse_all_day(item),
-                    # time_notes=self._parse_time_notes(item),
-                    # location=self._parse_location(item),
-                    # links=self._parse_links(item),
-                    # source=self._parse_source(response),
+                    title=self._parse_title(item),
+                    start=self._parse_start(item),
+                    links=self._parse_links(item),
+                    source=self._parse_source(response)
                 )
 
-                # meeting["status"] = self._get_status(meeting)
-                # meeting["id"] = self._get_id(meeting)
+                meeting["status"] = self._get_status(meeting)
+                meeting["id"] = self._get_id(meeting)
 
-                # yield meeting
+                yield meeting
         else:
             event_days = response.selector.xpath(".//td[@class='cal_dayshasevents']")
             for item in event_days:
-                date = item.xpath(".//a[@class='cal_daylink']//span[@class='listview']/text()").get().lstrip()
+                date = item. \
+                        xpath(".//a[@class='cal_daylink']//span[@class='listview']/text()"). \
+                        get(). \
+                        lstrip()
                 events = item.xpath(".//a[@class='cal_titlelink']")
                 for event in events:
 
@@ -59,9 +52,13 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
                     print(name.split()[0].isupper())
                     print(time)
 
+    def convert_date(self, date_str):
+        date_str = datetime.strptime(date_str, "%b %d, %Y")
+        return date_str
+
     def _parse_title(self, item):
         """Parse or generate meeting title."""
-        return ""
+        return item.xpath(".//td[@class='djc_category']/span/text()").get()
 
     def _parse_description(self, item):
         """Parse or generate meeting description."""
@@ -73,7 +70,8 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
 
     def _parse_start(self, item):
         """Parse start datetime as a naive datetime object."""
-        return None
+        date = item.xpath(".//td[@class='djc_producer']/span/text()").get()
+        return datetime.datetime.strptime(date, "%B %d, %Y")
 
     def _parse_end(self, item):
         """Parse end datetime as a naive datetime object. Added by pipeline if None"""
@@ -96,7 +94,18 @@ class ChiOhareNoiseSpider(CityScrapersSpider):
 
     def _parse_links(self, item):
         """Parse or generate links."""
-        return [{"href": "", "title": ""}]
+        agenda_minute = item.xpath(".//li[@class='djc_file']")
+        agenda_href = agenda_minute[0].xpath(".//a/@href").get()
+        minute_href = agenda_minute[1].xpath(".//a/@href").get()
+
+        links = []
+        if agenda_href is not None:
+            links.append({"href": agenda_href, "title": "Agenda"})
+
+        if minute_href is not None:
+            links.append({"href": minute_href, "title": "Minutes"})
+
+        return links
 
     def _parse_source(self, response):
         """Parse or generate source."""

--- a/tests/files/chi_ohare_noise.html
+++ b/tests/files/chi_ohare_noise.html
@@ -1,0 +1,751 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-gb" lang="en-gb" dir="ltr">
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<base href="https://www.oharenoise.org/about-oncc/agendas-and-minutes" />
+	<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+	<meta name="keywords" content="O’Hare Noise Compatibility Commission (ONCC)" />
+	<meta name="description" content="The O’Hare Noise Compatibility Commission (ONCC) is the only inter-governmental agency that is dedicated to reducing aircraft noise in the communities around O’Hare International Airport. It was established in 1996, following an invitation from the City of Chicago to suburban mayors to begin constructive dialogues on aircraft noise issues." />
+	<title>Agendas and Minutes Archive - O'Hare Noise Compatibility Commission</title>
+	<link href="/about-oncc/agendas-and-minutes?start=20" rel="next" />
+	<link href="/about-oncc/agendas-and-minutes" rel="canonical" />
+	<link href="/about-oncc/agendas-and-minutes?format=feed&amp;type=rss" rel="alternate" type="application/rss+xml" title="RSS 2.0" />
+	<link href="/about-oncc/agendas-and-minutes?format=feed&amp;type=atom" rel="alternate" type="application/atom+xml" title="Atom 1.0" />
+	<link href="/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
+	<link href="/media/system/css/modal.css?927b8338d8832af1f3770662547a3d7c" rel="stylesheet" type="text/css" />
+	<link href="https://www.oharenoise.org/components/com_djcatalog2/assets/slimbox-1.8/css/slimbox.css" rel="stylesheet" type="text/css" />
+	<link href="https://www.oharenoise.org/components/com_djcatalog2/themes/default/css/theme.css" rel="stylesheet" type="text/css" />
+	<link href="/media/jui/css/chosen.css?927b8338d8832af1f3770662547a3d7c" rel="stylesheet" type="text/css" />
+	<link href="/media/com_finder/css/finder.css?927b8338d8832af1f3770662547a3d7c" rel="stylesheet" type="text/css" />
+	<link href="/modules/mod_djmegamenu/themes/default/css/djmegamenu.css?v=4.0.0.pro" rel="stylesheet" type="text/css" />
+	<link href="/modules/mod_djmegamenu/mobilethemes/dark/djmobilemenu.css?v=4.0.0.pro" rel="stylesheet" type="text/css" />
+	<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css" />
+	<style type="text/css">
+ .djc_item .djc_mainimage { margin-left: 4px; margin-bottom: 4px; }  .djc_item .djc_mainimage img { padding: 4px; }  .djc_item .djc_thumbnail { margin-left: 4px; margin-bottom: 4px; }  .djc_item .djc_thumbnail img {  padding: 4px;  }  .djc_item .djc_images {width: 312px; }  .djc_item .djc_thumbnail { width: 100px; }  .djc_items .djc_image img { padding: 4px;} .djc_related_items .djc_image img { padding: 4px;} .djc_items .djc_image img {max-width: 120px;} .djc_category .djc_mainimage { margin-left: 4px; margin-bottom: 4px; }  .djc_category .djc_mainimage img { padding: 4px; }  .djc_category .djc_thumbnail { margin-left: 4px; margin-bottom: 4px; }  .djc_category .djc_thumbnail img {  padding: 4px;  }  .djc_category .djc_images {width: 312px; }  .djc_category .djc_thumbnail { width: 100px; }  .djc_subcategory .djc_image img { padding: 4px;} .djc_subcategory .djc_image img {max-width: 120px;} .djc_producer .djc_mainimage { margin-left: 4px; margin-bottom: 4px; }  .djc_producer .djc_mainimage img { padding: 4px; }  .djc_producer .djc_thumbnail { margin-left: 4px; margin-bottom: 4px; }  .djc_producer .djc_thumbnail img {  padding: 4px;  }  .djc_producer .djc_images {width: 312px; }  .djc_producer .djc_thumbnail { width: 100px; } 		.dj-hideitem { display: none !important; }
+
+		@media (min-width: 971px) {	
+			#dj-megamenu156mobile { display: none; }
+		}
+		@media (max-width: 970px) {
+			#dj-megamenu156, #dj-megamenu156sticky, #dj-megamenu156placeholder { display: none !important; }
+		}
+	
+	</style>
+	<script type="application/json" class="joomla-script-options new">{"csrf.token":"b7d187f9f6e4adac414d7854bee5c301","system.paths":{"root":"","base":""}}</script>
+	<script src="/media/jui/js/jquery.min.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/jui/js/jquery-noconflict.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/jui/js/jquery-migrate.min.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/system/js/mootools-core.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/system/js/core.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/system/js/mootools-more.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/system/js/modal.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="https://www.oharenoise.org/components/com_djcatalog2/assets/slimbox-1.8/js/slimbox.js" type="text/javascript"></script>
+	<script src="https://www.oharenoise.org/components/com_djcatalog2/themes/default/js/theme.js" type="text/javascript"></script>
+	<script src="/media/jui/js/bootstrap.min.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/jui/js/chosen.jquery.min.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/media/jui/js/jquery.autocomplete.min.js?927b8338d8832af1f3770662547a3d7c" type="text/javascript"></script>
+	<script src="/modules/mod_djmegamenu/assets/js/jquery.djmobilemenu.js?v=4.0.0.pro" type="text/javascript" defer="defer"></script>
+	<script type="text/javascript">
+
+		jQuery(function($) {
+			SqueezeBox.initialize({});
+			SqueezeBox.assign($('a.modal').get(), {
+				parse: 'rel'
+			});
+		});
+
+		window.jModalClose = function () {
+			SqueezeBox.close();
+		};
+		
+		// Add extra modal close functionality for tinyMCE-based editors
+		document.onreadystatechange = function () {
+			if (document.readyState == 'interactive' && typeof tinyMCE != 'undefined' && tinyMCE)
+			{
+				if (typeof window.jModalClose_no_tinyMCE === 'undefined')
+				{	
+					window.jModalClose_no_tinyMCE = typeof(jModalClose) == 'function'  ?  jModalClose  :  false;
+					
+					jModalClose = function () {
+						if (window.jModalClose_no_tinyMCE) window.jModalClose_no_tinyMCE.apply(this, arguments);
+						tinyMCE.activeEditor.windowManager.close();
+					};
+				}
+		
+				if (typeof window.SqueezeBoxClose_no_tinyMCE === 'undefined')
+				{
+					if (typeof(SqueezeBox) == 'undefined')  SqueezeBox = {};
+					window.SqueezeBoxClose_no_tinyMCE = typeof(SqueezeBox.close) == 'function'  ?  SqueezeBox.close  :  false;
+		
+					SqueezeBox.close = function () {
+						if (window.SqueezeBoxClose_no_tinyMCE)  window.SqueezeBoxClose_no_tinyMCE.apply(this, arguments);
+						tinyMCE.activeEditor.windowManager.close();
+					};
+				}
+			}
+		};
+		jQuery(function($){ initTooltips(); $("body").on("subform-row-add", initTooltips); function initTooltips (event, container) { container = container || document;$(container).find(".hasTooltip").tooltip({"html": true,"container": "body"});} });
+	jQuery(function ($) {
+		initChosen();
+		$("body").on("subform-row-add", initChosen);
+
+		function initChosen(event, container)
+		{
+			container = container || document;
+			$(container).find(".advancedSelect").chosen({"disable_search_threshold":10,"search_contains":true,"allow_single_deselect":true,"placeholder_text_multiple":"Type or select some options","placeholder_text_single":"Select an option","no_results_text":"No results match"});
+		}
+	});
+	
+jQuery(document).ready(function() {
+	var value, searchword = jQuery('#mod-finder-searchword161');
+
+		// Get the current value.
+		value = searchword.val();
+
+		// If the current value equals the default value, clear it.
+		searchword.on('focus', function ()
+		{
+			var el = jQuery(this);
+
+			if (el.val() === 'Search ...')
+			{
+				el.val('');
+			}
+		});
+
+		// If the current value is empty, set the previous value.
+		searchword.on('blur', function ()
+		{
+			var el = jQuery(this);
+
+			if (!el.val())
+			{
+				el.val(value);
+			}
+		});
+
+		jQuery('#mod-finder-searchform161').on('submit', function (e)
+		{
+			e.stopPropagation();
+			var advanced = jQuery('#mod-finder-advanced161');
+
+			// Disable select boxes with no value selected.
+			if (advanced.length)
+			{
+				advanced.find('select').each(function (index, el)
+				{
+					var el = jQuery(el);
+
+					if (!el.val())
+					{
+						el.attr('disabled', 'disabled');
+					}
+				});
+			}
+		});
+	var suggest = jQuery('#mod-finder-searchword161').autocomplete({
+		serviceUrl: '/component/finder/?task=suggestions.suggest&amp;format=json&amp;tmpl=component',
+		paramName: 'q',
+		minChars: 1,
+		maxHeight: 400,
+		width: 300,
+		zIndex: 9999,
+		deferRequestBy: 500
+	});});
+	</script>
+	<meta property="og:title" content="Agendas and Minutes Archive - O'Hare Noise Compatibility Commission" />
+	<meta property="twitter:title" content="Agendas and Minutes Archive - O'Hare Noise Compatibility Commission" />
+	<meta property="og:url" content="http://www.oharenoise.org/about-oncc/agendas-and-minutes" />
+
+<!--[if lt IE 9]>
+<script src="/media/jui/js/html5.js"></script>
+<![endif]-->
+<link rel="stylesheet" href="/templates/onccnew/css/bootstrap.css" type="text/css" />
+<link rel="stylesheet" href="/templates/onccnew/css/template.css" type="text/css" />
+</head>
+<body><div class="dj-offcanvas-wrapper"><div class="dj-offcanvas-pusher"><div class="dj-offcanvas-pusher-in">
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-48009529-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+<div id="container">
+  <div id="header" class="clearfix">
+    <div id="header_logo"><a href="/"><img src="/templates/onccnew/images/logo.png" alt="O’Hare Noise Compatibility Commission" /></a></div><div id="header_links"><ul class="nav menu mod-list" id="topnav">
+<li class="item-957"><a href="https://www.boarddocs.com/il/oncc/Board.nsf/Public" class=" first" target="_blank" rel="noopener noreferrer"><img src="/sitemedia/images/global/icon-agenda.png" alt="Meeting Documents" /><span class="image-title">Meeting Documents</span></a></li><li class="item-138"><a href="/resources/publications" ><img src="/sitemedia/images/global/icon-publications.png" alt="Publications" /><span class="image-title">Publications</span></a></li><li class="item-815"><a href="/e-news" ><img src="/sitemedia/images/global/icon-enews.png" alt="E-News" /><span class="image-title">E-News</span></a></li><li class="item-161"><a href="https://311.chicago.gov/s/article/Aircraft-noise-complaints?language=en_US" target="_blank" rel="noopener noreferrer"><img src="/sitemedia/images/global/icon-complaints.png" alt="Noise Complaints" /><span class="image-title">Noise Complaints</span></a></li><li class="item-137 parent"><a href="/contact-us" ><img src="/sitemedia/images/global/icon-contact.png" alt="Contact Us" /><span class="image-title">Contact Us</span></a></li></ul>
+
+
+<div class="custom-htagline"  >
+	<p>43 Communities and 22 School Districts Dedicated to Reducing Aircraft Noise</p></div>
+</div>
+  </div>
+  <div id="navigation">
+<div class="dj-megamenu-wrapper">
+
+
+<ul id="dj-megamenu156" class="dj-megamenu dj-megamenu-default horizontalMenu "
+	 data-trigger="970">
+<li class="dj-up itemid101 first"><a class="dj-up_a  " href="/" ><span >Home</span></a></li><li class="dj-up itemid107 active parent separator"><a class="dj-up_a active "   tabindex="0"><span class="dj-drop" >About ONCC<em class="arrow" aria-hidden="true"></em></span></a><div class="dj-subwrap  single_column subcols1" style=""><div class="dj-subwrap-in" style="width:220px;"><div class="dj-subcol" style="width:220px"><ul class="dj-submenu"><li class="itemid193 first"><a href="/about-oncc/about-us" >About Us</a></li><li class="itemid111"><a href="/about-oncc/leadership" >ONCC Leadership</a></li><li class="itemid317"><a href="/about-oncc/committees" >Committees</a></li><li class="itemid142"><a class=" hidemobile" href="/about-oncc/oncc-meetings/month.calendar/2019/06/23/-" >Meetings</a></li><li class="itemid194"><a class=" hidedesktop" href="/about-oncc/oncc-meetings-m/month.calendar/2019/06/23/-" >Meetings</a></li><li class="itemid813"><a href="/about-oncc/agendas-minutes-intro" >Agendas and Minutes</a></li><li class="itemid153 current active"><a class="active hide" href="/about-oncc/agendas-and-minutes" >Agendas and Minutes Archive</a></li><li class="itemid197"><a href="/about-oncc/resolutions" >Resolutions</a></li><li class="itemid168"><a href="/about-oncc/members" >Members</a></li><li class="itemid115"><a href="/about-oncc/newsroom" >Newsroom</a></li><li class="itemid118"><a href="/about-oncc/community-outreach" >Community Outreach</a></li></ul></div><div style="clear:both;height:0"></div></div></div></li><li class="dj-up itemid108 parent separator"><a class="dj-up_a  "   tabindex="0"><span class="dj-drop" >Noise Mitigation<em class="arrow" aria-hidden="true"></em></span></a><div class="dj-subwrap  single_column subcols1" style=""><div class="dj-subwrap-in" style="width:220px;"><div class="dj-subcol" style="width:220px"><ul class="dj-submenu"><li class="itemid112 first"><a class=" subtitle" href="/noise-mitigation/residential" >Residential</a></li><li class="itemid154"><a class=" subitem" href="/noise-mitigation/residential-committee" >Residential Committee</a></li><li class="itemid155"><a class=" subitem" href="/noise-mitigation/residential-facts" >Residential Facts</a></li><li class="itemid121"><a class=" subtitle" href="/noise-mitigation/schools" >Schools</a></li><li class="itemid156"><a class=" subitem" href="/noise-mitigation/schools-committee" >Schools Committee</a></li><li class="itemid122"><a class=" subitem" href="/noise-mitigation/school-facts" >School Facts</a></li></ul></div><div style="clear:both;height:0"></div></div></div></li><li class="dj-up itemid109 parent separator"><a class="dj-up_a  "   tabindex="0"><span class="dj-drop" >Noise Management<em class="arrow" aria-hidden="true"></em></span></a><div class="dj-subwrap  single_column subcols1" style=""><div class="dj-subwrap-in" style="width:220px;"><div class="dj-subcol" style="width:220px"><ul class="dj-submenu"><li class="itemid124 first"><a href="/noise-management/technical-committee" >Technical Committee</a></li><li class="itemid223"><a href="/noise-management/technical-faqs" >Technical FAQs</a></li><li class="itemid260"><a href="/noise-management/fly-quiet-program" >Fly Quiet Program</a></li><li class="itemid803"><a href="/noise-management/fly-quiet-committee" >Fly Quiet Committee</a></li><li class="itemid125"><a href="/noise-management/noise-monitors" >Noise Monitors</a></li><li class="itemid238"><a href="/noise-management/noise-reports" >O'Hare Noise Reports</a></li><li class="itemid128"><a href="/noise-management/performance-based-navigation" >NextGen</a></li></ul></div><div style="clear:both;height:0"></div></div></div></li><li class="dj-up itemid110 parent separator"><a class="dj-up_a  "   tabindex="0"><span class="dj-drop" >Resources<em class="arrow" aria-hidden="true"></em></span></a><div class="dj-subwrap  single_column subcols1" style=""><div class="dj-subwrap-in" style="width:220px;"><div class="dj-subcol" style="width:220px"><ul class="dj-submenu"><li class="itemid758 first"><a href="/resources/charts-and-maps" >Charts and Maps</a></li><li class="itemid222"><a href="/resources/frequently-asked-questions" >Frequently Asked Questions</a></li><li class="itemid116"><a href="/resources/publications" >Publications</a></li><li class="itemid589"><a href="/resources/presentations" >Presentations</a></li><li class="itemid130"><a href="/resources/links" >Links</a></li><li class="itemid131"><a href="/resources/land-use" >Land Use</a></li><li class="itemid157"><a href="http://www.flychicago.com/SiteCollectionDocuments/Community/Noise/OHare/N101/NoiseGlossaryofTermsAcronyms061113.pdf" target="_blank" >Glossary of Terms</a></li><li class="itemid814"><a href="/resources/o-hare-21" >O'Hare 21</a></li><li class="itemid117"><a href="/resources/o-hare-modernization" >O'Hare Modernization</a></li><li class="itemid132"><a href="/resources/building-codes" >Building Codes</a></li></ul></div><div style="clear:both;height:0"></div></div></div></li></ul>
+
+
+	<div id="dj-megamenu156mobile" class="dj-megamenu-accordion dj-megamenu-accordion-dark dj-pos-static  dj-align-left ">
+		<a href="#" class="dj-mobile-open-btn" aria-label="Open mobile menu"><span class="fa fa-bars" aria-hidden="true"></span></a>		
+		<div class="dj-accordion dj-accordion-dark ">
+			<div class="dj-accordion-in">
+				<ul class="dj-mobile-nav dj-mobile-dark ">
+<li class="dj-mobileitem itemid-101"><a href="/" >Home</a></li><li class="dj-mobileitem itemid-107 active divider deeper parent"><a   tabindex="0">About ONCC</a><ul class="dj-mobile-nav-child"><li class="dj-mobileitem itemid-193"><a href="/about-oncc/about-us" >About Us</a></li><li class="dj-mobileitem itemid-111"><a href="/about-oncc/leadership" >ONCC Leadership</a></li><li class="dj-mobileitem itemid-317"><a href="/about-oncc/committees" >Committees</a></li><li class="dj-mobileitem itemid-142"><a class=" hidemobile" href="/about-oncc/oncc-meetings/month.calendar/2019/06/23/-" >Meetings</a></li><li class="dj-mobileitem itemid-194"><a class=" hidedesktop" href="/about-oncc/oncc-meetings-m/month.calendar/2019/06/23/-" >Meetings</a></li><li class="dj-mobileitem itemid-813"><a href="/about-oncc/agendas-minutes-intro" >Agendas and Minutes</a></li><li class="dj-mobileitem itemid-153 current active"><a class=" hide" href="/about-oncc/agendas-and-minutes" >Agendas and Minutes Archive</a></li><li class="dj-mobileitem itemid-197"><a href="/about-oncc/resolutions" >Resolutions</a></li><li class="dj-mobileitem itemid-168"><a href="/about-oncc/members" >Members</a></li><li class="dj-mobileitem itemid-115 parent"><a href="/about-oncc/newsroom" >Newsroom</a></li><li class="dj-mobileitem itemid-118"><a href="/about-oncc/community-outreach" >Community Outreach</a></li></ul></li><li class="dj-mobileitem itemid-108 divider deeper parent"><a   tabindex="0">Noise Mitigation</a><ul class="dj-mobile-nav-child"><li class="dj-mobileitem itemid-112 parent"><a class=" subtitle" href="/noise-mitigation/residential" >Residential</a></li><li class="dj-mobileitem itemid-154"><a class=" subitem" href="/noise-mitigation/residential-committee" >Residential Committee</a></li><li class="dj-mobileitem itemid-155"><a class=" subitem" href="/noise-mitigation/residential-facts" >Residential Facts</a></li><li class="dj-mobileitem itemid-121 parent"><a class=" subtitle" href="/noise-mitigation/schools" >Schools</a></li><li class="dj-mobileitem itemid-156"><a class=" subitem" href="/noise-mitigation/schools-committee" >Schools Committee</a></li><li class="dj-mobileitem itemid-122"><a class=" subitem" href="/noise-mitigation/school-facts" >School Facts</a></li></ul></li><li class="dj-mobileitem itemid-109 divider deeper parent"><a   tabindex="0">Noise Management</a><ul class="dj-mobile-nav-child"><li class="dj-mobileitem itemid-124 parent"><a href="/noise-management/technical-committee" >Technical Committee</a></li><li class="dj-mobileitem itemid-223 parent"><a href="/noise-management/technical-faqs" >Technical FAQs</a></li><li class="dj-mobileitem itemid-260"><a href="/noise-management/fly-quiet-program" >Fly Quiet Program</a></li><li class="dj-mobileitem itemid-803 parent"><a href="/noise-management/fly-quiet-committee" >Fly Quiet Committee</a></li><li class="dj-mobileitem itemid-125 parent"><a href="/noise-management/noise-monitors" >Noise Monitors</a></li><li class="dj-mobileitem itemid-238 parent"><a href="/noise-management/noise-reports" >O'Hare Noise Reports</a></li><li class="dj-mobileitem itemid-128"><a href="/noise-management/performance-based-navigation" >NextGen</a></li></ul></li><li class="dj-mobileitem itemid-110 divider deeper parent"><a   tabindex="0">Resources</a><ul class="dj-mobile-nav-child"><li class="dj-mobileitem itemid-758"><a href="/resources/charts-and-maps" >Charts and Maps</a></li><li class="dj-mobileitem itemid-222"><a href="/resources/frequently-asked-questions" >Frequently Asked Questions</a></li><li class="dj-mobileitem itemid-116"><a href="/resources/publications" >Publications</a></li><li class="dj-mobileitem itemid-589"><a href="/resources/presentations" >Presentations</a></li><li class="dj-mobileitem itemid-130"><a href="/resources/links" >Links</a></li><li class="dj-mobileitem itemid-131"><a href="/resources/land-use" >Land Use</a></li><li class="dj-mobileitem itemid-157"><a href="http://www.flychicago.com/SiteCollectionDocuments/Community/Noise/OHare/N101/NoiseGlossaryofTermsAcronyms061113.pdf" target="_blank" >Glossary of Terms</a></li><li class="dj-mobileitem itemid-814"><a href="/resources/o-hare-21" >O'Hare 21</a></li><li class="dj-mobileitem itemid-117 parent"><a href="/resources/o-hare-modernization" >O'Hare Modernization</a></li><li class="dj-mobileitem itemid-132"><a href="/resources/building-codes" >Building Codes</a></li></ul></li></ul>
+			</div>
+		</div>
+	</div>
+
+
+</div></div>
+  <div id="content">
+  		              <div id="main" class="clearfix"><div id="breadcrumbs"></div><div id="system-message-container">
+	</div>
+<div id="djcatalog" class="djc_list djc_theme_default">
+
+
+  
+
+
+	<h1 class="componentheading djc_page_heading">
+		Agendas and Minutes Archive	</h1>
+
+
+
+
+	<div class="djc_filters djc_clearfix" id="tlb">
+		<div class="djc_filters_in thumbnail">
+	<form name="djcatalogForm" id="djcatalogForm" method="post" action="/about-oncc/agendas-and-minutes?task=search">
+					<ul class="djc_filter_list djc_clearfix">
+				<li class="span2 djc_filter_label"><span>Meetings:</span></li>
+									<li class="djc_filter_input djc_filter_categories"><select id="cid" name="cid" class="inputbox input">
+	<option value="" selected="selected">- - Select Meeting - -</option>
+	<option value="4">ONCC General Meeting</option>
+	<option value="1">Residential Sound Insulation Committee</option>
+	<option value="2">School Sound Insulation Program Committee</option>
+	<option value="3">Technical Committee</option>
+	<option value="5">Executive Committee</option>
+	<option value="7">Ad-Hoc Budget Committee</option>
+	<option value="6">Ad-Hoc By-Laws Committee</option>
+	<option value="8">Ad-Hoc Nominating Committee</option>
+	<option value="9">Strategic Planning</option>
+	<option value="10">Ad-Hoc Fly Quiet Committee</option>
+	<option value="11">Fly Quiet Committee</option>
+	<option value="12">Governance Committee</option>
+</select>
+					<script type="text/javascript">
+					//<![CDATA[ 
+					document.id('cid').addEvent('change',function(evt){
+						if(document.id('pid')) {
+							options = document.id('pid').getElements('option');
+							options.each(function(option, index){
+								if (option.value == "") {
+									option.setAttribute('selected', 'true');
+								} else {
+									option.removeAttribute('selected');
+								}
+							});
+						}
+
+						document.djcatalogForm.submit();
+					});
+					//]]>
+					</script>
+					</li>
+													<li class="djc_filter_input djc_filter_producers"><select id="pid" name="pid" class="inputbox input">
+	<option value="0" selected="selected">- - Select Year - -</option>
+	<option value="18">2019</option>
+	<option value="17">2018</option>
+	<option value="16">2017</option>
+	<option value="15">2016</option>
+	<option value="14">2015</option>
+	<option value="13">2014</option>
+	<option value="12">2013</option>
+	<option value="11">2012</option>
+	<option value="10">2011</option>
+	<option value="9">2010</option>
+	<option value="8">2009</option>
+</select>
+</li>
+					<script type="text/javascript">
+						//<![CDATA[ 
+						document.id('pid').addEvent('change',function(evt){
+							document.djcatalogForm.submit();
+						});
+						//]]>
+					</script>
+							</ul>
+			<div class="clear"></div>
+										<input type="hidden" name="option" value="com_djcatalog2" />
+	<input type="hidden" name="view" value="items" />
+	<input type="hidden" name="order" value="i.meetingdate" />
+	<input type="hidden" name="dir" value="desc" />
+	<input type="hidden" name="task" value="search" />
+	<input type="hidden" name="Itemid" value="153" />
+	</form>
+	
+		
+</div>			</div>
+
+
+
+
+
+	<div class="djc_items djc_clearfix">
+		<table width="100%" cellpadding="0" cellspacing="0" class="djc_items_table jlist-table category table table-condensed" id="djc_items_table">
+	<thead>
+		<tr>
+							<th class="djc_thead djc_th_image">&nbsp;</th>
+							        										<th class="djc_thead djc_th_category" nowrap="nowrap">
+					Meeting				</th>
+										<th class="djc_thead djc_th_producer" nowrap="nowrap">
+					Date				</th>
+							                <th class="djc_thead djc_th_price" nowrap="nowrap">
+	                		<div class="djc_files"><ul><li>Agenda</li><li>Minutes</li></ul></div>
+
+	                </th>
+						
+						
+										            </tr>
+            </thead>
+            <tbody>
+                <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>ONCC General Meeting</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>June 7, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=539"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Executive Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>June 3, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=538"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Governance Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>May 16, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=532"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Residential Sound Insulation Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>May 15, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=531"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Technical Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>May 14, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=530"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>ONCC General Meeting</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>May 3, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=529"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Executive Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>April 29, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=527"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Fly Quiet Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>April 23, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=526"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Ad-Hoc Nominating Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>April 18, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=521"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=537"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Governance Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>April 17, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=517"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=536"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Technical Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>April 16, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=522"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=533"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>ONCC General Meeting</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>April 5, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=516"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=535"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Executive Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>April 1, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=515"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=534"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Fly Quiet Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>March 22, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=514"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Technical Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>March 19, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=513"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=525"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Residential Sound Insulation Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>March 13, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=512"><span>Agenda</span></a></li><li class="djc_file">&nbsp;</li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>ONCC General Meeting</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>March 1, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=503"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=518"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Executive Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>February 26, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=505"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=519"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row0 djc_row0">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Fly Quiet Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>February 19, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=501"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=524"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+	        <tr class="cat-list-row1 djc_row1">
+            	            <td class="djc_image">
+	                	            </td>
+                                    								<td class="djc_category" >
+					<span>Fly Quiet Committee</span> 
+                            										</td>
+										<td class="djc_producer">
+									<span>January 22, 2019</span>
+															</td>
+					           <td class="djc_price">
+                
+<div class="djc_files">
+<ul>
+
+
+<li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=500"><span>Agenda</span></a></li><li class="djc_file"><a target="_blank" class="button" href="/about-oncc/agendas-and-minutes?format=raw&amp;task=download&amp;fid=510"><span>Minutes</span></a></li>
+</ul>
+</div>            </td>
+										        </tr>
+		</tbody>
+</table>
+	</div>
+
+
+<div class="djc_pagination pagination djc_clearfix">
+<ul>
+	<li class="pagination-start"><span class="pagenav">Start</span></li>
+	<li class="pagination-prev"><span class="pagenav">Prev</span></li>
+			<li><span class="pagenav">1</span></li>			<li><a href="/about-oncc/agendas-and-minutes?start=20" class="pagenav">2</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=40" class="pagenav">3</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=60" class="pagenav">4</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=80" class="pagenav">5</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=100" class="pagenav">6</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=120" class="pagenav">7</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=140" class="pagenav">8</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=160" class="pagenav">9</a></li>			<li><a href="/about-oncc/agendas-and-minutes?start=180" class="pagenav">10</a></li>		<li class="pagination-next"><a title="Next" href="/about-oncc/agendas-and-minutes?start=20" class="hasTooltip pagenav">Next</a></li>
+	<li class="pagination-end"><a title="End" href="/about-oncc/agendas-and-minutes?start=260" class="hasTooltip pagenav">End</a></li>
+</ul>
+</div>
+
+
+
+</div>
+
+</div>
+            	 
+    <a href="#0" class="cd-top"></a>
+<script src="/templates/oncc/js/script.js"></script>
+  </div>
+  
+  <div id="footer">
+    <div id="newsletter">		<div class="moduletable newsletter">
+							<h3>Subscribe to our Newsletter</h3>
+						
+
+<div class="custom newsletter"  >
+	<form action="https://ui.constantcontact.com/d.jsp" method="post" name="ccoptin" target="_blank">
+<p><label>Email Address:</label><input name="ea" type="text" value="" /><input name="go" type="submit" value="Subscribe" class="submit" /><input name="m" type="hidden" value="1101102832932" /><input name="p" type="hidden" value="oi" /></p>
+</form></div>
+		</div>
+	</div>
+    <div id="search">		<div class="moduletable">
+							<h3>Website Search</h3>
+						
+<div class="finder">
+	<form id="mod-finder-searchform161" action="/website-search" method="get" class="form-search" role="search">
+		<label for="mod-finder-searchword161" class="element-invisible finder">Website Search</label><br /><input type="text" name="q" id="mod-finder-searchword161" class="search-query input-medium" size="20" value="" placeholder="Search ..."/><button class="btn btn-primary hasTooltip  finder" type="submit" title="Go"><span class="icon-search icon-white"></span>Search</button>
+							</form>
+</div>
+		</div>
+	</div>
+    <div id="copyright"><p>&copy; 2019 O’Hare Noise Compatibility Commission. All Rights Reserved</p></div>
+  </div>
+  
+</div>
+<script type="text/javascript">/*joomlatools job scheduler*/
+!function(){function e(e,t,n,o){try{o=new(this.XMLHttpRequest||ActiveXObject)("MSXML2.XMLHTTP.3.0"),o.open("POST",e,1),o.setRequestHeader("X-Requested-With","XMLHttpRequest"),o.setRequestHeader("Content-type","application/x-www-form-urlencoded"),o.onreadystatechange=function(){o.readyState>3&&t&&t(o.responseText,o)},o.send(n)}catch(c){}}function t(n){e(n,function(e,o){try{if(200==o.status){var c=JSON.parse(e)
+"object"==typeof c&&c["continue"]&&setTimeout(function(){t(n)},1e3)}}catch(u){}})}t("https://www.oharenoise.org/index.php?option=com_joomlatools&controller=scheduler")}()</script></div></div></div></body>
+</html>

--- a/tests/test_chi_ohare_noise.py
+++ b/tests/test_chi_ohare_noise.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+from city_scrapers_core.constants import NOT_CLASSIFIED
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.chi_ohare_noise import ChiOhareNoiseSpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "chi_ohare_noise.html"),
+    url="https://www.oharenoise.org/about-oncc/agendas-and-minutes",
+)
+spider = ChiOhareNoiseSpider()
+
+freezer = freeze_time("2019-06-23")
+freezer.start()
+
+parsed_items = [item for item in spider.parse(test_response)]
+
+freezer.stop()
+
+
+def test_tests():
+    print("Please write some tests for this spider or at least disable this one.")
+    assert False
+
+
+"""
+Uncomment below
+"""
+
+# def test_title():
+#     assert parsed_items[0]["title"] == "EXPECTED TITLE"
+
+
+# def test_description():
+#     assert parsed_items[0]["description"] == "EXPECTED DESCRIPTION"
+
+
+# def test_start():
+#     assert parsed_items[0]["start"] == datetime(2019, 1, 1, 0, 0)
+
+
+# def test_end():
+#     assert parsed_items[0]["end"] == datetime(2019, 1, 1, 0, 0)
+
+
+# def test_time_notes():
+#     assert parsed_items[0]["time_notes"] == "EXPECTED TIME NOTES"
+
+
+# def test_id():
+#     assert parsed_items[0]["id"] == "EXPECTED ID"
+
+
+# def test_status():
+#     assert parsed_items[0]["status"] == "EXPECTED STATUS"
+
+
+# def test_location():
+#     assert parsed_items[0]["location"] == {
+#         "name": "EXPECTED NAME",
+#         "address": "EXPECTED ADDRESS"
+#     }
+
+
+# def test_source():
+#     assert parsed_items[0]["source"] == "EXPECTED URL"
+
+
+# def test_links():
+#     assert parsed_items[0]["links"] == [{
+#       "href": "EXPECTED HREF",
+#       "title": "EXPECTED TITLE"
+#     }]
+
+
+# def test_classification():
+#     assert parsed_items[0]["classification"] == NOT_CLASSIFIED
+
+
+# @pytest.mark.parametrize("item", parsed_items)
+# def test_all_day(item):
+#     assert item["all_day"] is False


### PR DESCRIPTION
Problem:
Having trouble yielding meetings after all detail pages for each meeting have been scraped. Because of scrapy's use of Twisted which deals with concurrent network calls, yielding requests causes them to be downloaded and processed concurrently making it difficult to determined when the meeting items are ready to be yielded.

Goal:
Determine when all detail pages have been scraped and data has been processed so I can yield all the meetings at the same time.

Current solution:
yield meetings even if all of the meeting info has not been scraped then yield them again when the rest of the data is scraped