### PR TITLE
Add wayne_land_bank spider

### DIFF
--- a/city_scrapers/spiders/wayne_land_bank.py
+++ b/city_scrapers/spiders/wayne_land_bank.py
@@ -15,7 +15,7 @@ class WayneLandBankSpider(CityScrapersSpider):
     start_urls = ["https://public-wclb.epropertyplus.com/landmgmtpub/app/base/customPage"]
     location = {
         "name": "Wayne County Treasurer's Office",
-        "address": "400 Monroe St 5th Floor, Detroit, MI 48226, United States",
+        "address": "400 Monroe St 5th Floor, Detroit, MI 48226",
     }
 
     def start_requests(self):
@@ -36,24 +36,26 @@ class WayneLandBankSpider(CityScrapersSpider):
         Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
         needs.
         """
-        data = response.xpath('//script[@id="custom_page_template"]/text()').extract()
+        self.response_data = response.xpath('//script[@id="custom_page_template"]/text()').extract()
         data = re.findall(
             '(Jan(?:uary)|Feb(?:ruary)|Mar(?:ch)|Apr(?:il)|May|Jun(?:e)|Jul(?:y)'
             '|Aug(?:ust)|Sep(?:tember)|Oct(?:ober)|Nov(?:ember)|Dec(?:ember))'
             r'(.*?)(?=\.\s|\\n)'
-            '(.*?)(?=\\n)', data[0]
+            '(.*?)(?=\\n)', self.response_data[0]
         )
+
+        self._validate_location(self.response_data)
 
         for item in data:
             meeting = Meeting(
-                title=item[2].strip(" .()"),
+                title='Board of Directors ' + item[2].strip(" .()"),
                 description="",
                 classification=BOARD,
                 start=self._parse_start("".join(item[0:2])),
                 end=None,
                 all_day=False,
                 time_notes="",
-                location=self._parse_location(""),
+                location=self.location,
                 links=[],
                 source=response.url,
             )
@@ -71,6 +73,7 @@ class WayneLandBankSpider(CityScrapersSpider):
         start_datetime = datetime.strptime(item, "%B %d, %Y at %I %p")
         return start_datetime
 
-    def _parse_location(self, item):
-        """Parse or generate location."""
-        return self.location
+    def _validate_location(self, data):
+        if '400 Monroe' not in re.findall('The Board of Directors holds meetings at (.*?)(?=\\n)',
+                                          data[0])[0]:
+            raise ValueError("Meeting location has changed")

--- a/city_scrapers/spiders/wayne_land_bank.py
+++ b/city_scrapers/spiders/wayne_land_bank.py
@@ -47,8 +47,10 @@ class WayneLandBankSpider(CityScrapersSpider):
         self._validate_location(self.response_data)
 
         for item in data:
+            title = item[2].strip(" .()")
+            title = 'Board of Directors' if not title else 'Board of Directors ' + title
             meeting = Meeting(
-                title='Board of Directors ' + item[2].strip(" .()"),
+                title=title,
                 description="",
                 classification=BOARD,
                 start=self._parse_start("".join(item[0:2])),

--- a/city_scrapers/spiders/wayne_land_bank.py
+++ b/city_scrapers/spiders/wayne_land_bank.py
@@ -76,6 +76,7 @@ class WayneLandBankSpider(CityScrapersSpider):
         return start_datetime
 
     def _validate_location(self, data):
-        if '400 Monroe' not in re.findall('The Board of Directors holds meetings at (.*?)(?=\\n)',
-                                          data[0])[0]:
+        if '400 Monroe' not in re.findall(
+            'The Board of Directors holds meetings at (.*?)(?=\\n)', data[0]
+        )[0]:
             raise ValueError("Meeting location has changed")

--- a/city_scrapers/spiders/wayne_land_bank.py
+++ b/city_scrapers/spiders/wayne_land_bank.py
@@ -1,0 +1,76 @@
+import re
+from datetime import datetime
+
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+from scrapy.http import FormRequest
+
+
+class WayneLandBankSpider(CityScrapersSpider):
+    name = "wayne_land_bank"
+    agency = "Wayne County Land Bank"
+    timezone = "America/Detroit"
+    allowed_domains = ["public-wclb.epropertyplus.com"]
+    start_urls = ["https://public-wclb.epropertyplus.com/landmgmtpub/app/base/customPage"]
+    location = {
+        "name": "Wayne County Treasurer's Office",
+        "address": "400 Monroe St 5th Floor, Detroit, MI 48226, United States",
+    }
+
+    def start_requests(self):
+        yield FormRequest(
+            self.start_urls[0],
+            formdata={
+                "templateName": "BoardofDirectors",
+                "title": "Board+of+Directors"
+            },
+            callback=self.parse,
+            dont_filter=True
+        )
+
+    def parse(self, response):
+        """
+        `parse` should always `yield` Meeting items.
+
+        Change the `_parse_title`, `_parse_start`, etc methods to fit your scraping
+        needs.
+        """
+        data = response.xpath('//script[@id="custom_page_template"]/text()').extract()
+        data = re.findall(
+            '(Jan(?:uary)|Feb(?:ruary)|Mar(?:ch)|Apr(?:il)|May|Jun(?:e)|Jul(?:y)'
+            '|Aug(?:ust)|Sep(?:tember)|Oct(?:ober)|Nov(?:ember)|Dec(?:ember))'
+            r'(.*?)(?=\.\s|\\n)'
+            '(.*?)(?=\\n)', data[0]
+        )
+
+        for item in data:
+            meeting = Meeting(
+                title=item[2].strip(" .()"),
+                description="",
+                classification=BOARD,
+                start=self._parse_start("".join(item[0:2])),
+                end=None,
+                all_day=False,
+                time_notes="",
+                location=self._parse_location(""),
+                links=[],
+                source=response.url,
+            )
+
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+
+            yield meeting
+
+    def _parse_start(self, item):
+        """Parse start datetime as a naive datetime object."""
+        item = item.replace('p.m', 'pm')
+        item = item.replace('a.m', 'am')
+        item = re.sub(r':\d{1,2}', '', item)
+        start_datetime = datetime.strptime(item, "%B %d, %Y at %I %p")
+        return start_datetime
+
+    def _parse_location(self, item):
+        """Parse or generate location."""
+        return self.location

--- a/tests/files/wayne_land_bank.html
+++ b/tests/files/wayne_land_bank.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html class="gr__public-wclb_epropertyplus_com" data-lt-installed="true" lang="en"><head>
+
+	<link rel="shortcut icon" href="https://public-wclb.epropertyplus.com/landmgmtpub/favicon.ico" type="image/x-icon">
+	<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    
+        
+        
+    
+
+	<title>Wayne County Land Bank</title>
+	
+	<script async="" src="Wayne%20County%20Land%20Bank_files/analytics.js"></script><script>
+	
+	function CheckBrowser() {
+	    if ('localStorage' in window && window['localStorage'] !== null) {
+	        // we can use localStorage object to store data
+	        return true;
+	    } else {
+	        return false;
+	    }
+	}
+	
+		var contextPath = "/landmgmtpub",
+			eppTrackingId = 'UA-35681285-2',
+			tenantTrackingId = '',  
+			tenantName = 'Wayne County Land Bank',
+			tenantId = '30',
+			tenantUID = '7c9727035e0ab430',
+			tenantFullAddress = '500 Griswold, Suite 2800, Detroit MI 48226 ',
+			supportEmail = 'wclbinquiries@waynecounty.com',
+			supportPhone = '(313) 967-3669',
+			environment = 'prod',
+			allowSubmissions = true,
+			disclaimer = 'Property\x20data\x20contained\x20on\x20this\x20site\x20is\x20intended\x20for\x20informational\x20purposes.\x20Although\x20Wayne\x20County\x20Land\x20Bank\x20Corporation\x20makes\x20every\x20effort\x20to\x20ensure\x20that\x20data\x20displayed\x20online\x20is\x20current\x20and\x20correct,\x20it\x20cannot\x20guarantee\x20the\x20accuracy\x20of\x20property\x20listings,\x20map\x20imagery,\x20or\x20parcel\x20availability.\x20By\x20accessing\x20this\x20site,\x20I\x20acknowledge\x20that\x20its\x20data\x20reflects\x20publically\x2Dsourced\x20estimates\x20and\x20is\x20subject\x20to\x20change.',
+			googleMapKey = 'AIzaSyBgKOA_n0OOjkbJKwGraRDf_KgW-IXhkxE',
+			cartoDBUser = 'epropertyplus';
+	</script>
+		
+    <!-- basic styles -->
+    <link href="Wayne%20County%20Land%20Bank_files/bootstrap.css" rel="stylesheet">
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/font-awesome.css">
+
+    <!--[if IE 7]>
+    <link rel="stylesheet" href="/landmgmtpub/resources/acetheme/css/font-awesome-ie7.min.css?d=20190916183021"/>
+    <![endif]-->
+
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/jquery-ui-1.css">
+    
+    <!-- fonts -->
+
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/ace-fonts.css">
+
+    <!-- ace styles -->
+
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/ace.css">
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/ace-rtl.css">
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/ace-skins.css">
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/custom.css">
+
+    <!--[if lte IE 8]>
+    <link rel="stylesheet" href="/landmgmtpub/resources/acetheme/css/ace-ie.min.css?d=20190916183021"/>
+    <![endif]-->
+
+    <!-- ace settings handler -->
+
+    <script type="text/javascript" src="Wayne%20County%20Land%20Bank_files/bheader1.js"></script>
+
+    <!--[if lt IE 9]>
+<script type="text/javascript" src="/landmgmtpub/jsJawrPath/gzip_545848039/bundles/bheader2.js" ></script>
+<![endif]-->
+
+
+    <link rel="stylesheet" href="Wayne%20County%20Land%20Bank_files/bheader.css">
+
+<style>
+
+    .navbar {
+        background: #438eb9;
+    }
+
+
+
+</style>
+        
+</head>
+
+
+
+<body data-gr-c-s-loaded="true">
+	<div id="wrap" style="overflow:hidden;">
+		
+ 
+
+
+<nav class="navbar navbar-default" role="navigation" id="navbar">
+    <!-- Brand and toggle get grouped for better mobile display -->
+    <div class="navbar-header">
+        <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
+        
+            
+                <a class="navbar-brand" href="#"><img style="height: 30px; max-width: 66px" class="banner-logo" alt="Logo" src="Wayne%20County%20Land%20Bank_files/LandBank-Logo-smaller.jpg"> Wayne County Land Bank</a>
+            
+            
+        
+    </div>
+
+    <!-- Collect the nav links, forms, and other content for toggling -->
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+        <ul class="nav navbar-nav navbar-right">                
+	      
+		     
+		     
+		     
+		            <li><a href="https://public-wclb.epropertyplus.com/landmgmtpub/app/base/landing">Home</a></li>
+					<li class="customMenuPlaceholder" style="display: none;"></li>
+	<li><a href="#" onclick="showHelp();">Help</a></li>
+<!-- Sample Drop down menu -->
+<li class="dropdown">
+ <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">About Us<span class="caret"></span></a>
+ <ul class="dropdown-menu">
+  <li><a href="#" onclick="showCustomPage('Staff','Staff');">Staff</a></li>
+<p>
+  </p><li><a href="#" onclick="showCustomPage('BoardofDirectors','Board of Directors');">Board of Directors</a></li>
+<p>
+  </p><li><a href="#" onclick="showCustomPage('Programs','Programs');">Programs</a></li>  
+
+ </ul>
+</li>
+<!-- Sample Drop down menu -->
+<li>
+</li><li class="dropdown">
+ <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Documents<span class="caret"></span></a>
+ <ul class="dropdown-menu">
+  <li><a href="#" onclick="showCustomPage('CommonEvidenceExhibitforNuisanceAbatement','Common Evidence Exhibit for Nuisance Abatement');">Common Evidence Exhibit for Nuisance Abatement</a></li></ul>
+</li>
+		            
+		     	    <li><a href="https://public-wclb.epropertyplus.com/landmgmtpub/app/base/login"><i class="icon-user"></i> Login</a></li>
+		     	    
+		      
+		   		 
+        </ul>
+    </div>
+    <form id="customPage" method="post">
+    	<input type="hidden" name="templateName" id="templateName">
+    	<input type="hidden" name="title" id="title">
+    </form>
+    <!-- /.navbar-collapse -->
+</nav>
+
+<script type="text/x-handlebars-template" id="site_menu_template">
+	<li><a href="#" onclick="showHelp();">Help</a></li>
+<!-- Sample Drop down menu -->
+<li class="dropdown">
+ <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">About Us<span class="caret"></span></a>
+ <ul class="dropdown-menu">
+  <li><a href="#" onclick="showCustomPage('Staff','Staff');">Staff</a></li>
+<p>
+  <li><a href="#" onclick="showCustomPage('BoardofDirectors','Board of Directors');">Board of Directors</a></li>
+<p>
+  <li><a href="#" onclick="showCustomPage('Programs','Programs');">Programs</a></li>  
+
+ </ul>
+</li>
+<!-- Sample Drop down menu -->
+<li>
+<li class="dropdown">
+ <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Documents<span class="caret"></span></a>
+ <ul class="dropdown-menu">
+  <li><a href="#" onclick="showCustomPage('CommonEvidenceExhibitforNuisanceAbatement','Common Evidence Exhibit for Nuisance Abatement');">Common Evidence Exhibit for Nuisance Abatement</a></li></ul>
+</script>
+
+
+
+		<div class="breadcrumbs" id="breadcrumbs">
+			<ul class="breadcrumb">
+				<li><i class="icon-home home-icon"></i><a href="https://public-wclb.epropertyplus.com/landmgmtpub/app/base/landing">Home</a></li>
+				
+					<li class="active">Board of Directors</li>
+				
+			</ul>
+			<!-- .breadcrumb -->
+		</div>
+		
+		<div id="customPageContent">
+		<div class="col-lg-4" style="padding-left:25px;  min-height:400px;">
+The Board of Directors holds meetings at the Wayne County Treasurer's Office at 400 Monroe, Detroit, MI.
+<p>
+</p><p>
+<b>Remaining Dates for 2018</b>
+</p><p>
+January 17, 2019 at 2 p.m.
+</p><p>
+February 20, 2019 at 11:0 a.m. (Special Meeting).
+</p><p>
+April 18, 2019 at 2 p.m. 
+</p><p>
+August 15, 2019 at 2 p.m. 
+</p><p>
+November 21, 2019 at 2 p.m.
+<br>
+<br>
+<b> Current Board Members</b>
+</p><p>
+</p><ul>
+&nbsp;&nbsp;&nbsp;&nbsp;
+<li><b>Eric Sabree</b>, Board Chairman, Wayne County Treasurer
+</li><li><b>Irma Clark-Coleman</b>, Wayne County Commissioner, District 5
+</li><li><b>Gary Evanko</b>, City of Dearborn Director of Assessment
+</li><li><b>Andrew Kandrevas</b>, Office of the Wayne County Executive
+</li><li><b>Tony Saunders</b>
+</li></ul>
+</div>	
+	</div>
+	</div>
+
+	<div id="footer">
+	<div class="container">
+    <div class="row">
+    	<div class="vspace-10"></div>
+        <div class="col-md-4">
+            <ul class="list-unstyled" style="color: #67737a;">
+                <li>
+                    <span style="font-weight: bold;color: #428bca;">Wayne County Land Bank</span>&nbsp;
+                    <span style="font-weight: bold;color: #428bca;">500 Griswold, Suite 2800, Detroit MI 48226 </span><br>&nbsp;
+                </li>
+                <li>
+                   <span style="font-weight: bold;color: #428bca;">QUESTIONS&nbsp;&nbsp;</span>&nbsp;(313) 967-3669<br>
+                    <span style="font-weight: bold;color: #428bca;">EMAIL&nbsp;&nbsp;</span>&nbsp;wclbinquiries@waynecounty.com
+                </li>
+            </ul>
+        </div>
+        <div class="col-md-8">
+        	
+        </div>
+    </div>
+</div>
+</div>
+
+<script id="site_footer_template" type="text/x-handlebars-template">
+	<div class="container">
+    <div class="row">
+    	<div class="vspace-10"></div>
+        <div class="col-md-4">
+            <ul class="list-unstyled" style="color: #67737a;">
+                <li>
+                   {{#if tenantName}} <span style="font-weight: bold;color: #428bca;">{{tenantName}}</span>&nbsp;{{/if}}
+                   {{#if tenantFullAddress}} <span style="font-weight: bold;color: #428bca;">{{tenantFullAddress}}</span><br/>&nbsp;{{/if}}
+                </li>
+                <li>
+                {{#if supportPhone}}
+                   <span style="font-weight: bold;color: #428bca;">QUESTIONS&nbsp;&nbsp;</span>&nbsp;{{supportPhone}}<br/>{{/if}}
+                   {{#if supportEmail}}
+                    <span style="font-weight: bold;color: #428bca;">EMAIL&nbsp;&nbsp;</span>&nbsp;{{supportEmail}}{{/if}}
+                </li>
+            </ul>
+        </div>
+        <div class="col-md-8">
+        	
+        </div>
+    </div>
+</div>
+</script>
+
+	
+
+<!--[if !IE]-->
+<script type="text/javascript">
+    window.jQuery || document.write("<script src='/landmgmtpub/resources/js/jQuery/jquery-2.0.3.min.js'>" + "<" + "/script>");
+</script><script src="Wayne%20County%20Land%20Bank_files/jquery-2.js"></script>
+<!--[endif]-->
+
+<!--[if IE]>
+<script type="text/javascript">
+    window.jQuery || document.write("<script src='/landmgmtpub/resources/js/jQuery/jquery-1.10.2.min.js'>" + "<" + "/script>");
+</script>
+<![endif]-->
+
+
+<script type="text/javascript" src="Wayne%20County%20Land%20Bank_files/base.js"></script>
+ 
+
+	
+	<script type="text/javascript" src="Wayne%20County%20Land%20Bank_files/customPage.js"></script>
+
+	
+	<script type="text/x-handlebars-template" id="custom_page_template">
+		<div class="col-lg-4" style="padding-left:25px;  min-height:400px;">
+The Board of Directors holds meetings at the Wayne County Treasurer's Office at 400 Monroe, Detroit, MI.
+<p>
+<p>
+<b>Remaining Dates for 2018</b>
+<p>
+January 17, 2019 at 2 p.m.
+<p>
+February 20, 2019 at 11:0 a.m. (Special Meeting).
+<p>
+April 18, 2019 at 2 p.m. 
+<p>
+August 15, 2019 at 2 p.m. 
+<p>
+November 21, 2019 at 2 p.m.
+<br>
+<br>
+<b> Current Board Members</b>
+<p>
+<ul>
+&nbsp;&nbsp;&nbsp;&nbsp;
+<li><b>Eric Sabree</b>, Board Chairman, Wayne County Treasurer
+<li><b>Irma Clark-Coleman</b>, Wayne County Commissioner, District 5
+<li><b>Gary Evanko</b>, City of Dearborn Director of Assessment
+<li><b>Andrew Kandrevas</b>, Office of the Wayne County Executive
+<li><b>Tony Saunders</b>
+</ul>
+</div>	
+	</script>
+
+	<script>
+        sendGa({
+            'pageName' : '',
+            'title' : ''
+        });
+
+        sendGa({
+            'pageName' : ''
+        });
+    </script>	
+
+</body></html>

--- a/tests/test_wayne_land_bank.py
+++ b/tests/test_wayne_land_bank.py
@@ -23,8 +23,8 @@ freezer.stop()
 
 
 def test_title():
-    assert parsed_items[0]["title"] == ""
-    assert parsed_items[1]["title"] == "Special Meeting"
+    assert parsed_items[0]["title"] == "Board of Directors"
+    assert parsed_items[1]["title"] == "Board of Directors Special Meeting"
 
 
 def test_description():
@@ -58,7 +58,7 @@ def test_status():
 def test_location():
     assert parsed_items[0]["location"] == {
         "name": "Wayne County Treasurer's Office",
-        "address": "400 Monroe St 5th Floor, Detroit, MI 48226, United States"
+        "address": "400 Monroe St 5th Floor, Detroit, MI 48226"
     }
 
 

--- a/tests/test_wayne_land_bank.py
+++ b/tests/test_wayne_land_bank.py
@@ -1,0 +1,80 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.wayne_land_bank import WayneLandBankSpider
+
+test_response = file_response(
+    join(dirname(__file__), "files", "wayne_land_bank.html"),
+    url="https://public-wclb.epropertyplus.com/landmgmtpub/app/base/customPage",
+)
+spider = WayneLandBankSpider()
+
+freezer = freeze_time("2019-10-08")
+freezer.start()
+
+parsed_items = [item for item in spider.parse(test_response)]
+
+freezer.stop()
+
+
+def test_title():
+    assert parsed_items[0]["title"] == ""
+    assert parsed_items[1]["title"] == "Special Meeting"
+
+
+def test_description():
+    assert parsed_items[0]["description"] == ""
+
+
+def test_start():
+    assert parsed_items[0]["start"] == datetime(2019, 1, 17, 14, 0)
+    assert parsed_items[1]["start"] == datetime(2019, 2, 20, 11, 0)
+    assert parsed_items[2]["start"] == datetime(2019, 4, 18, 14, 0)
+    assert parsed_items[3]["start"] == datetime(2019, 8, 15, 14, 0)
+    assert parsed_items[4]["start"] == datetime(2019, 11, 21, 14, 0)
+
+
+def test_end():
+    assert parsed_items[0]["end"] is None
+
+
+def test_time_notes():
+    assert parsed_items[0]["time_notes"] == ""
+
+
+def test_id():
+    assert parsed_items[0]["id"] == "wayne_land_bank/201901171400/x/"
+
+
+def test_status():
+    assert parsed_items[0]["status"] == "passed"
+
+
+def test_location():
+    assert parsed_items[0]["location"] == {
+        "name": "Wayne County Treasurer's Office",
+        "address": "400 Monroe St 5th Floor, Detroit, MI 48226, United States"
+    }
+
+
+def test_source():
+    assert parsed_items[0][
+        "source"] == "https://public-wclb.epropertyplus.com/landmgmtpub/app/base/customPage"
+
+
+def test_links():
+    assert parsed_items[0]["links"] == []
+
+
+def test_classification():
+    assert parsed_items[0]["classification"] == BOARD
+
+
+@pytest.mark.parametrize("item", parsed_items)
+def test_all_day(item):
+    assert item["all_day"] is False

--- a/tests/test_wayne_land_bank.py
+++ b/tests/test_wayne_land_bank.py
@@ -48,7 +48,9 @@ def test_time_notes():
 
 
 def test_id():
-    assert parsed_items[0]["id"] == "wayne_land_bank/201901171400/x/"
+    assert parsed_items[0]["id"] == "wayne_land_bank/201901171400/x/board_of_directors"
+    assert parsed_items[1]["id"] == "wayne_land_bank/201902201100/x/board_of_directors"\
+                                    + "_special_meeting"
 
 
 def test_status():


### PR DESCRIPTION
This pull request adds the wayne_land_bank spider, the test file of that spider and target web page as an HTML file. 

-  To access the Board of Directors tab on the following page: https://public-wclb.epropertyplus.com/landmgmtpub/app/base/customPage we have to start with POST request.

- The desired data was included in `<script>` tags, thus to extract the data, the `re` regular expressions were used.

- The target site seems to be under the development, in the future the spider might require update if the website layer was changed or new information were added.   