### PR TITLE
Swap broken link for new Sublime linter link

### DIFF
--- a/docs/_docs/setuphelp.md
+++ b/docs/_docs/setuphelp.md
@@ -92,4 +92,4 @@ Most text editors can be configured to fix code style issues for you based off o
 }
 ```
 
-This configuration will run linting and style checks for you, and also make necessary changes automatically any time you save. Packages are available for [Atom](https://atom.io/packages/linter-flake8){:target="\_blank"} and [Sublime Text](https://fosstack.com/setup-sublime-python/){:target="\_blank"} as well.
+This configuration will run linting and style checks for you, and also make necessary changes automatically any time you save. Packages are available for [Atom](https://atom.io/packages/linter-flake8){:target="\_blank"} and [Sublime Text](https://janikarhunen.fi/three-steps-to-lint-python-3-6-in-sublime-text){:target="\_blank"} as well.


### PR DESCRIPTION
## Summary

I found a link in one of the docs that seemed corrupted: it seemed like it was supposed to lead to someone's blog but I think the address has since changed hands. I found another link that I believe fulfills the same purpose, which is to show an example of using automatic linting in setting up Sublime.

@pjsier it might be good to check out the new link https://janikarhunen.fi/three-steps-to-lint-python-3-6-in-sublime-text just to make sure you approve of the content, and let me know if it doesn't work for the purposes of these docs.