### PR TITLE
📖 Add install & run instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI build status](https://github.com/City-Bureau/city-scrapers/workflows/CI/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions?query=workflow%3ACI)
 [![Cron build status](https://github.com/City-Bureau/city-scrapers/workflows/Cron/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions?query=workflow%3ACron)
 
-A collection of scrapers for public meetings in Illinois, with a particular focus on Chicago.
+A collection of scrapers for public meetings in Cook County and Chicago, Illinois. Also includes scrapers for meetings of Illinois state boards.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ pipenv shell
 scrapy crawl <spider_name>
 ```
 
-3. For example, to trigger the `chi_citycouncil` spider to scrape Chicago City Council meeting information run:
+#### Example
+
+To trigger the `chi_citycouncil` spider to scrape Chicago City Council meeting information and output the results to a JSON file:
 
 ```bash
-scrapy crawl chi_citycouncil
+scrapy crawl chi_citycouncil -O citycouncil.json
 ```
 
 Alternatively, you can watch this [three minute video](https://www.youtube.com/watch?v=UgroG8CARWc) to see how to run a scraper.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ scrapy crawl <spider_name>
 scrapy crawl chi_citycouncil
 ```
 
-Alternatively, you can watch this [three minute video](https://www.youtube.com/watch?v=4Z3zXQYJXZc) to see how to run a scraper.
+Alternatively, you can watch this [three minute video](https://www.youtube.com/watch?v=UgroG8CARWc) to see how to run a scraper.
 
 ## About this project
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,39 @@
 [![CI build status](https://github.com/City-Bureau/city-scrapers/workflows/CI/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions?query=workflow%3ACI)
 [![Cron build status](https://github.com/City-Bureau/city-scrapers/workflows/Cron/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions?query=workflow%3ACron)
 
-## Who are the City Bureau Documenters, and why do they want to scrape websites?
+A collection of scrapers for public meetings in Illinois, with a particular focus on Chicago.
+
+## Getting Started
+
+### Install
+
+View our [installation guide](https://cityscrapers.org/docs/development/) for detailed instructions.
+
+### Run
+
+1. Activate the virtual environment:
+
+```bash
+pipenv shell
+```
+
+2. Run a scraper:
+
+```bash
+scrapy crawl <spider_name>
+```
+
+3. For example, to trigger the `chi_citycouncil` spider to scrape Chicago City Council meeting information run:
+
+```bash
+scrapy crawl chi_citycouncil
+```
+
+Alternatively, you can watch this [three minute video](https://www.youtube.com/watch?v=4Z3zXQYJXZc) to see how to run a scraper.
+
+## About this project
+
+### Who are the City Bureau Documenters, and why do they want to scrape websites?
 
 Public meetings are important spaces for democracy where any resident can participate and hold public figures accountable. [City Bureau's Documenters program](https://www.documenters.org/) pays community members an hourly wage to inform and engage their communities by attending and documenting public meetings.
 
@@ -11,13 +43,13 @@ How does the Documenters program know when meetings are happening? It isn’t ea
 
 That’s why City Bureau is working together with a team of civic coders to develop and coordinate the City Scrapers, a community open source project to scrape and store these meetings in a central database.
 
-## What are the City Scrapers?
+### What are the City Scrapers?
 
 The City Scrapers collect information about public meetings. Every day, the City Scrapers go out and fetch information about new meetings from the Chicago city council's website, the local school council's website, the Chicago police department's website, and many more. This happens automatically so that a person doesn't have to do it. The scrapers store all of the meeting information in a database for journalists at City Bureau to report on them.
 
 Community members are also welcome to use this code to set up their own databases.
 
-## What can I learn from working on the City Scrapers?
+### What can I learn from working on the City Scrapers?
 
 A lot about the City of Chicago! What is City Council talking about this week? What are the local school councils, and what community power do they have? What neighborhoods is the police department doing outreach in? Who governs our water?
 
@@ -29,17 +61,17 @@ From building a scraper, you'll gain experience with:
 - a basic data file format (JSON), working with a schema and data validation
 - problem-solving, finding patterns, designing robust code
 
-## How can I set up City Scrapers for my area?
+### How can I set up City Scrapers for my area?
 
 This repo is focused on Chicago, but you can set up City Scrapers for your area by following the instructions in the [City-Bureau/city-scrapers-template](https://github.com/city-bureau/city-scrapers-template) repo.
 
-## Community Mission
+### Community Mission
 
 The City Bureau Labs community welcomes contributions from everyone. We prioritize learning and leadership opportunities for under-represented individuals in tech and journalism.
 
 We hope that working with us will fill experience gaps (like using git/GitHub, working with data, or having your ideas taken seriously), so that more under-represented people will become decision-makers in both our community and Chicago’s tech and media scenes at large.
 
-## Ready to code with us?
+### Ready to code with us?
 
 1. [Fill out this form](https://airtable.com/shrRv027NLgToRFd6) to join our Slack channel and meet the community.
 2. Read about [how we collaborate](https://github.com/City-Bureau/city-scrapers/blob/main/CONTRIBUTING.md) and review our [Code of Conduct](https://github.com/City-Bureau/city-scrapers/blob/main/CODE_OF_CONDUCT.md).
@@ -47,7 +79,7 @@ We hope that working with us will fill experience gaps (like using git/GitHub, w
 
 We ask all new contributors to start by writing a spider and its documentation or fixing a bug in an existing one in order to gain familiarity with our code and culture. Reach out on Slack for support if you need it.
 
-## Don't want to code?
+### Don't want to code?
 
 [Join our Slack channel](https://airtable.com/shrRv027NLgToRFd6) (chatroom) to discuss ideas and meet the community!
 
@@ -55,7 +87,7 @@ A. We have ongoing conversations about what sort of data we should collect and h
 
 B. Research sources for public meetings. Answer questions like: Are we scraping events from the right websites? Are there local agencies that we're missing? Should events be updated manually or by a scraper? [Triage events sources on these issues](https://github.com/City-Bureau/city-scrapers/issues?q=is%3Aissue+is%3Aopen+label%3A%22non-coding%3A+triage+events+source%22).
 
-## Support this work
+### Support this work
 
 This project is organized and maintained by [City Bureau](http://www.citybureau.org/).
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Please note that if you're running this project on a Windows machine, you may ne
 
 ### What is City Scrapers?
 
-This repo part of an initiative to scrape, store and publish meeting information for public meetings across the U.S. It's coordinated by the [City Bureau Documenters program](https://www.documenters.org/) and heavily driven by community contributions. We welcome contributions from everyone, especially those with less experience in tech and journalism.
+This repo part of an initiative to scrape, store and publish meeting information for public meetings across the U.S. It's coordinated by the [City Bureau Documenters program](https://www.documenters.org/) and heavily driven by the open source community. We welcome contributions from everyone, especially those with little or no experience in tech and journalism.
 
 ### Why public meetings?
 
@@ -77,27 +77,23 @@ Public meetings are important spaces for democracy where any resident can partic
 
 [City Bureau's Documenters program](https://www.documenters.org/) pays community members, called Documenters, an hourly wage to inform and engage their communities by attending and documenting public meetings.
 
-How do Documenters know when meetings are happening? It isn’t easy! Meeting information is typically spread across dozens of websites and rarely in useful data formats. This project was started in order to automatically fetch meeting information and store it in a central database so that a person doesn't have to do it.
+A major challenge for Documenters is finding out when and where public meetings are happening and what's being discussed. Meeting information is typically spread across dozens of local government websites and rarely in useful data formats. This project was started in order to automatically fetch meeting information and store it in a central database so that a person doesn't have to do it manually.
 
-The scrapers in this repo fetch information about new meetings from the Chicago city council's website, the local school council's website, the Chicago police department's website, and many more.
+In this repo, our scrapers fetch information about new meetings from the websites of the Chicago City Council, the Chicago Police Department, the Chicago Board of Education, and many more. Information about these meetings is published on [City Bureau's Documenters website](https://www.documenters.org/), where it can be used by Documenters and other residents.
 
-### How can I set up City Scrapers for my area?
+### How can I help?
 
-This repo is focused on Chicago, but you can set up City Scrapers for your area by following the instructions in the [City-Bureau/city-scrapers-template](https://github.com/city-bureau/city-scrapers-template) repo.
+We welcome all contributions, including bug fixes, documentation improvements, and new scraper builds.
 
-### Community Mission
+Since local government websites can change without warning, we particularly appreciate contributions that fix our scrapers when they break. 
 
-The City Bureau Labs community welcomes contributions from everyone. We prioritize learning and leadership opportunities for under-represented individuals in tech and journalism.
-
-We hope that working with us will fill experience gaps (like using git/GitHub, working with data, or having your ideas taken seriously), so that more under-represented people will become decision-makers in both our community and Chicago’s tech and media scenes at large.
-
-### Ready to code with us?
+If you want to help:
 
 1. [Fill out this form](https://airtable.com/shrRv027NLgToRFd6) to join our Slack channel and meet the community.
 2. Read about [how we collaborate](https://github.com/City-Bureau/city-scrapers/blob/main/CONTRIBUTING.md) and review our [Code of Conduct](https://github.com/City-Bureau/city-scrapers/blob/main/CODE_OF_CONDUCT.md).
 3. Check out our [documentation](https://cityscrapers.org/docs/development/), and get started with [Installation](https://cityscrapers.org/docs/development/#installation) and [Contributing a spider](https://cityscrapers.org/docs/development/#contribute).
 
-We ask all new contributors to start by writing a spider and its documentation or fixing a bug in an existing one in order to gain familiarity with our code and culture. Reach out on Slack for support if you need it.
+We ask all new contributors to start by writing a spider and its documentation or fixing a bug in order to gain familiarity with our code and culture. Reach out on Slack for support if you need it.
 
 ### Don't want to code?
 
@@ -106,6 +102,10 @@ We ask all new contributors to start by writing a spider and its documentation o
 A. We have ongoing conversations about what sort of data we should collect and how it should be collected. Help us make these decisions by commenting on [issues with a non-coding label](https://github.com/City-Bureau/city-scrapers/issues?q=is%3Aissue+is%3Aopen+label%3Anon-coding).
 
 B. Research sources for public meetings. Answer questions like: Are we scraping events from the right websites? Are there local agencies that we're missing? Should events be updated manually or by a scraper? [Triage events sources on these issues](https://github.com/City-Bureau/city-scrapers/issues?q=is%3Aissue+is%3Aopen+label%3A%22non-coding%3A+triage+events+source%22).
+
+### Community Mission
+
+We hope that working with us will fill experience gaps (like using git/GitHub, working with data, or having your ideas taken seriously), so that more under-represented people will become decision-makers in both their community and the tech and media scenes at large.
 
 ### Support this work
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,36 @@ scrapy crawl chi_citycouncil -O citycouncil.json
 
 Alternatively, you can watch this [three minute video](https://www.youtube.com/watch?v=UgroG8CARWc) to see how to run a scraper.
 
+### Test
+
+1. If the virtual environment is not already active, activate it:
+
+```bash
+pipenv shell
+```
+
+2. Run all tests:
+```bash
+pytest
+```
+
+3. Run tests for a specific spider:
+```bash
+pytest tests/test_<spider_name>.py
+```
+
+#### Example
+
+To run tests for the `chi_citycouncil` spider:
+
+```bash
+pytest tests/test_chi_citycouncil.py
+```
+
+### Windows support
+
+Please note that if you're running this project on a Windows machine, you may need to install additional dependencies, such as [pywin32](https://pypi.org/project/pywin32/) or [pypiwin32](https://pypi.org/project/pypiwin32/).
+
 ## About this project
 
 ### Who are the City Bureau Documenters, and why do they want to scrape websites?

--- a/README.md
+++ b/README.md
@@ -67,31 +67,19 @@ Please note that if you're running this project on a Windows machine, you may ne
 
 ## About this project
 
-### Who are the City Bureau Documenters, and why do they want to scrape websites?
+### What is City Scrapers?
 
-Public meetings are important spaces for democracy where any resident can participate and hold public figures accountable. [City Bureau's Documenters program](https://www.documenters.org/) pays community members an hourly wage to inform and engage their communities by attending and documenting public meetings.
+This repo part of an initiative to scrape, store and publish meeting information for public meetings across the U.S. It's coordinated by the [City Bureau Documenters program](https://www.documenters.org/) and heavily driven by community contributions. We welcome contributions from everyone, especially those with less experience in tech and journalism.
 
-How does the Documenters program know when meetings are happening? It isn’t easy! These events are spread across dozens of websites, rarely in useful data formats.
+### Why public meetings?
 
-That’s why City Bureau is working together with a team of civic coders to develop and coordinate the City Scrapers, a community open source project to scrape and store these meetings in a central database.
+Public meetings are important spaces for democracy where any resident can participate and hold public figures accountable. Unfortunately, with the collapse of local news media in the U.S., hundreds of public meetings happen every week with no journalists in attendance. This means that residents are often unaware of the decisions being made in their area.
 
-### What are the City Scrapers?
+[City Bureau's Documenters program](https://www.documenters.org/) pays community members, called Documenters, an hourly wage to inform and engage their communities by attending and documenting public meetings.
 
-The City Scrapers collect information about public meetings. Every day, the City Scrapers go out and fetch information about new meetings from the Chicago city council's website, the local school council's website, the Chicago police department's website, and many more. This happens automatically so that a person doesn't have to do it. The scrapers store all of the meeting information in a database for journalists at City Bureau to report on them.
+How do Documenters know when meetings are happening? It isn’t easy! Meeting information is typically spread across dozens of websites and rarely in useful data formats. This project was started in order to automatically fetch meeting information and store it in a central database so that a person doesn't have to do it.
 
-Community members are also welcome to use this code to set up their own databases.
-
-### What can I learn from working on the City Scrapers?
-
-A lot about the City of Chicago! What is City Council talking about this week? What are the local school councils, and what community power do they have? What neighborhoods is the police department doing outreach in? Who governs our water?
-
-From building a scraper, you'll gain experience with:
-
-- how the web works (HTTP requests and responses, reading HTML)
-- writing functions and tests in Python
-- version control and collaborative coding (git and Github)
-- a basic data file format (JSON), working with a schema and data validation
-- problem-solving, finding patterns, designing robust code
+The scrapers in this repo fetch information about new meetings from the Chicago city council's website, the local school council's website, the Chicago police department's website, and many more.
 
 ### How can I set up City Scrapers for my area?
 


### PR DESCRIPTION
## What's this PR do?

Adds more detail to our readme, rewords sections and reformats. In particular, it adds notes about how to run individual spiders and test them.

## Why are we doing this?

I think this information is helpful for first-time users of this repo or those unfamiliar with Scrapy's API. 

My motivation here is driven heavily by my own experience: this repo was my introduction to the city scrapers project and – even as someone with pipenv and Scrapy experience – I was somewhat frustrated there weren't better notes in the readme about how to get started. Since our goal is to make the City Scraper project as approachable as possible to folks who don't have much coding experience, I think it's important we make these instructions simple and clear.

## Are there any smells or added technical debt to note?

The readmes for each city scraper repo take divergent approaches. Some, like Akron and Fresno, are barebones and simply link to our [full documentation webpage](https://cityscrapers.org/docs/getting-started/). Others, like [Indy](https://github.com/City-Bureau/city-scrapers-indianapolis?tab=readme-ov-file) and [Philly](https://github.com/City-Bureau/city-scrapers-indianapolis?tab=readme-ov-file), include quite detailed setup instructions.

I see a strong argument for the Akron/Fresno approach because it means we can have essentially a single source of truth for our documentation. However, to my mind, I quite like the idea of a hybrid approach: we link to our webpage for some details (like install instructions) but include notes on other stuff that isn't likely to change, like triggering a scraper and what the City Scrapers project is. I'm hopeful this makes the repo more accessible to people because they don't have to open up a whole new webpage.

I propose the structure of this readme is also adopted by our repos but I welcome feedback here. Again, there may be a strong argument for simply linking to our city-scrapers.org documentation page.
