### PR TITLE
⚙️ Prevent github workflow deactivation

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -61,3 +61,6 @@ jobs:
 
       - name: Prevent workflow deactivation
         uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+          committer_username: "citybureau-bot"
+          committer_email: "documenters@citybureau.org"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -58,3 +58,6 @@ jobs:
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH
           pipenv run scrapy combinefeeds -s LOG_ENABLED=False
+
+      - name: Prevent workflow deactivation
+        uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
## What's this PR do?
Adds an extra step to our scheduled scrape workflow (named "cron") that will automatically create a dummy commit in the repo if the last commit to the repo was 50 days ago.

## Why are we doing this? 

We recently discovered that workflows in a number of our city-scraper repos were disabled by Github because there had been no commits in 60 days. Adding this extra step to our workflow using a third party Github action called [keepalive-workflow](https://github.com/marketplace/actions/keepalive-workflow) should prevent that.

## Steps to manually test

I manually triggered our `cron` workflow from this branch (`keepalive`) in order to ensure the workflow executed and didn't causing unexpected problems. Here's the [output](https://github.com/City-Bureau/city-scrapers/actions/runs/7451651828/job/20273217175). If you wish to replicate, do the following. Keep in mind the workflow will take about an hour to run:

1) Manually trigger our cron workflow from the [Github Actions page](https://github.com/City-Bureau/city-scrapers/actions/workflows/cron.yml) using the "keepalive" branch.
2) Monitor the output. Ensure that the scrape executes without error
3) Ensure that keepalive-workflow doesn't throw any errors and appears to execute.

![image](https://github.com/City-Bureau/city-scrapers/assets/37225902/6cac4918-98e5-4d9e-9365-0a26ef69680c)

## Are there any smells or added technical debt to note? 
- Creating a dummy commit to prevent Github from disabling our workflows is kind of a hacky workaround to solve the deactivation issue. It's easy for me to imagine that further down the line Github might change its criteria for when it disables workflows. It's also unfortunate that we'll be littering our git history with dummy commits. Nevertheless, using [keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow) seems to be the fastest and easiest solution to this problem based on the discussion I found ([SO question](https://github.com/connorads/stackoverflow-fanatic/issues/3), Github [issue comments](https://github.com/connorads/stackoverflow-fanatic/issues/3#issuecomment-1283461324)).
- This third party workflow looks reasonably legit. At time of writing, the repo appears to be actively maintained (last commit Dec, 2023), has 147 stars, and [no real issues](https://github.com/gautamkrishnar/keepalive-workflow/issues). The core logic is [pretty simple](https://github.com/gautamkrishnar/keepalive-workflow/blob/0f1f730ce2b049e5f646b9440ba548b7271dc2b1/library.js). I also tested out the keepalive workflow on a testing branch. I configured the workflow to make a dummy commit after 0 days of inactivity. It seemed to [work](https://github.com/City-Bureau/city-scrapers/actions/runs/7451651828/job/20273217175) as expected, successfully creating a dummy commit: 
![image](https://github.com/City-Bureau/city-scrapers/assets/37225902/6d41428c-11b8-41a4-9804-a39375d0c553)
- One headache with using this workflow is that it will fail if we've enabled rules on our main branch that requires a PR before merging. This issue is [flagged](https://github.com/gautamkrishnar/keepalive-workflow/issues/17) by the workflow's author. I believe most of our repos do not have branch protection enabled but, nevertheless, I think it would be ideal if they did. I experimented with a bypass rule for our workflow but was unsuccessful (discussion [here](https://github.com/orgs/community/discussions/13836)). It seems like the simplest solution is simply to maintain the status quo and not enable main/master branch protection across our repos. This isn't ideal but it might an acceptable tradeoff for now.

![image](https://github.com/City-Bureau/city-scrapers/assets/37225902/e0f81dd9-48f0-4903-a5d1-a20fd5ed94da)

