### PR TITLE
Fix to chicago library spyder

### DIFF
--- a/city_scrapers/spiders/chi_library.py
+++ b/city_scrapers/spiders/chi_library.py
@@ -74,7 +74,7 @@ class ChiLibrarySpider(CityScrapersSpider):
         """
         Parse start date and time.
         """
-        dt_str = item.css("strong::text").extract()[-1]
+        dt_str = item.css("strong::text").extract()[0]
         return datetime.datetime.strptime(
             "{} {}".format(re.sub(r"[,\.]", "", dt_str), year), "%A %B %d %I %p %Y"
         )


### PR DESCRIPTION

## Summary

**Issue:** #N/A
There's an issue with the Chicago Library spyder where if there's multiple dates with the strong tag then it'd go with the last one which currently causes an issue with the website if ran.


## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [ x] Tests are implemented
- [x ] All tests are passing
- [x ] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [x ] Style checks are passing
- [x ] Code comments from template removed


