### PR TITLE
Fixed issues with chi_metro_pier_exposition spyder in parsing date

### DIFF
--- a/city_scrapers/spiders/chi_metro_pier_exposition.py
+++ b/city_scrapers/spiders/chi_metro_pier_exposition.py
@@ -1,4 +1,5 @@
 from datetime import datetime, time
+import dateutil.parser
 
 from city_scrapers_core.constants import BOARD, COMMITTEE
 from city_scrapers_core.items import Meeting
@@ -72,8 +73,8 @@ class ChiMetroPierExpositionSpider(CityScrapersSpider):
 
     def _parse_start(self, item, classification):
         """Parse start datetime as a naive datetime object."""
-        date_str = item.css("td::text").extract_first().strip()
-        date_obj = datetime.strptime(date_str, "%B %d, %Y").date()
+        date_str = item.css("td::text").extract_first().strip().split("*")[-1]
+        date_obj = dateutil.parser.parse(date_str)
         time_obj = time(9)
         if classification == COMMITTEE:
             time_obj = time(13, 30)


### PR DESCRIPTION
## Summary

**Issue:** #N/A
There's an issue with the chi_metro_pier_exposition spyder where it wasn't parsing the date correctly. It wasn't parsing a date with an apostrophe correctly where the apostrophes indicating the dates been rescheduled and wasn't parsing differing date formats. 

## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [x ] Tests are implemented
- [x ] All tests are passing
- [x ] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [ x] Style checks are passing
- [ x] Code comments from template removed

