### PR TITLE
Remove keep alive step to prevent blocking/failing cron

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -58,15 +58,3 @@ jobs:
         run: |
           export PYTHONPATH=$(pwd):$PYTHONPATH
           pipenv run scrapy combinefeeds -s LOG_ENABLED=False
-
-  keepalive-workflow:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prevent workflow deactivation
-        uses: gautamkrishnar/keepalive-workflow@v2
-        with:
-          auto_write_check: "true"
-          workflow_files: "archive.yml"


### PR DESCRIPTION
This PR removes the keepalive-workflow step from the cron workflow.