### PR TITLE
fix build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # City Scrapers
 
-[![CI build status](https://github.com/City-Bureau/city-scrapers/workflows/CI/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions?query=workflow%3ACI)
-[![Cron build status](https://github.com/City-Bureau/city-scrapers/workflows/Cron/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions?query=workflow%3ACron)
+[![CI build status](https://github.com/City-Bureau/city-scrapers/actions/workflows/ci.yml/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions/workflows/ci.yml)
+[![Cron build status](https://github.com/City-Bureau/city-scrapers/actions/workflows/cron.yml/badge.svg)](https://github.com/City-Bureau/city-scrapers/actions/workflows/cron.yml)
 
 ## Who are the City Bureau Documenters, and why do they want to scrape websites?
 


### PR DESCRIPTION
## Summary

Fix the build status badges so that they accurately reflect the statuses on the default branch.

## Checklist

All checks are run in [GitHub Actions](https://github.com/features/actions). You'll be able to see the results of the checks at the bottom of the pull request page after it's been opened, and you can click on any of the specific checks listed to see the output of each step and debug failures.

- [ ] Tests are implemented
- [ ] All tests are passing
- [ ] Style checks run (see [documentation](https://cityscrapers.org/docs/development/) for more details)
- [ ] Style checks are passing
- [ ] Code comments from template removed

## Questions

Include any questions you have about what you're working on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README badges for CI and Cron to use GitHub Actions workflow-specific badges.
  * Replaced outdated links with direct references to actions/workflows/ci.yml and actions/workflows/cron.yml.
  * Refreshed badge image URLs and targets for accurate status display.
  * No functional changes to the application; improvements are limited to documentation clarity and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->