### PR TITLE
Fix OpenVPN installation

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Connect to OpenVPN
         run: |
+          sudo apt-get update
           sudo apt-get install -y openvpn
           echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
           echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Connect to OpenVPN
         run: |
+          sudo apt-get update
           sudo apt-get install -y openvpn
           echo "$OPENVPN_USER" | sudo tee -a /etc/openvpn/client/auth
           echo "$OPENVPN_PASS" | sudo tee -a /etc/openvpn/client/auth


### PR DESCRIPTION
- Refreshes package index before installing openvpn to prevent 404 errors when GitHub runner's cached package list is stale.
<img width="1901" height="1008" alt="Screenshot 2025-12-01 at 11 36 39" src="https://github.com/user-attachments/assets/25f1e8a4-7d21-4380-afb2-4a0748b3815b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline workflows to ensure package lists are refreshed before installing dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->