### PR TITLE
🕷️Fix spider: Metropolitan Water Reclamation District of Greater Chicago

### DIFF
--- a/city_scrapers/spiders/cook_water.py
+++ b/city_scrapers/spiders/cook_water.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import datetime, timedelta
 
 from city_scrapers_core.constants import BOARD, COMMITTEE, FORUM
@@ -41,6 +42,66 @@ class CookWaterSpider(LegistarSpider):
             meeting["status"] = self._get_status(meeting, event["Meeting Location"])
             meeting["id"] = self._get_id(meeting)
             yield meeting
+
+    def _parse_legistar_events(self, response):
+        events_table = response.css("table.rgMasterTable")[0]
+
+        headers = []
+        for header in events_table.css("th[class^='rgHeader']"):
+            header_text = (
+                " ".join(header.css("*::text").extract()).replace("&nbsp;", " ").strip()
+            )
+            header_inputs = header.css("input")
+            if header_text:
+                headers.append(header_text)
+            elif len(header_inputs) > 0:
+                headers.append(header_inputs[0].attrib["value"])
+            else:
+                headers.append(header.css("img")[0].attrib["alt"])
+
+        events = []
+        for row in events_table.css("tr.rgRow, tr.rgAltRow"):
+            try:
+                data = defaultdict(lambda: None)
+                for header, field in zip(headers, row.css("td")):
+                    field_text = (
+                        " ".join(field.css("*::text").extract())
+                        .replace("&nbsp;", " ")
+                        .strip()
+                    )
+                    url = None
+                    if len(field.css("a")) > 0:
+                        link_el = field.css("a")[0]
+                        if "onclick" in link_el.attrib and link_el.attrib[
+                            "onclick"
+                        ].startswith(("radopen('", "window.open", "OpenTelerikWindow")):
+                            url = response.urljoin(
+                                link_el.attrib["onclick"].split("'")[1]
+                            )
+                        elif "href" in link_el.attrib:
+                            url = response.urljoin(link_el.attrib["href"])
+                    if url:
+                        # Detect iCal by URL pattern, not header name
+                        if "View.ashx?M=IC" in url:
+                            header = "iCalendar"
+                            value = {"url": url}
+                        else:
+                            value = {"label": field_text, "url": url}
+                    else:
+                        value = field_text
+
+                    data[header] = value
+
+                ical_url = data.get("iCalendar", {}).get("url")
+                if ical_url is None or ical_url in self._scraped_urls:
+                    continue
+                else:
+                    self._scraped_urls.add(ical_url)
+                events.append(dict(data))
+            except Exception:
+                pass
+
+        return events
 
     def _parse_classification(self, name):
         """

--- a/city_scrapers/spiders/cook_water.py
+++ b/city_scrapers/spiders/cook_water.py
@@ -13,6 +13,11 @@ class CookWaterSpider(LegistarSpider):
     start_urls = ["https://mwrd.legistar.com/Calendar.aspx"]
     address = "100 East Erie Street Chicago, IL 60611"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.since_year = 2008
+        self.legistar_keys = set()
+
     def parse_legistar(self, events):
         three_months_ago = datetime.today() - timedelta(days=90)
         for event in events:

--- a/city_scrapers/spiders/cook_water.py
+++ b/city_scrapers/spiders/cook_water.py
@@ -11,11 +11,15 @@ class CookWaterSpider(LegistarSpider):
     agency = "Metropolitan Water Reclamation District of Greater Chicago"
     event_timezone = "America/Chicago"
     start_urls = ["https://mwrd.legistar.com/Calendar.aspx"]
-    address = "100 East Erie Street Chicago, IL 60611"
+    location = {
+        "name": "Board Room",
+        "address": "100 East Erie Street Chicago, IL 60611",
+    }
+    link_types = ["Meeting Details", "Accessible Agenda", "Accessible Minutes"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.since_year = 2008
+        self.since_year = 2020
         self.legistar_keys = set()
 
     def parse_legistar(self, events):
@@ -40,7 +44,7 @@ class CookWaterSpider(LegistarSpider):
                 end=None,
                 time_notes="",
                 all_day=False,
-                location=self._parse_location(event),
+                location=self.location,
                 links=self.legistar_links(event),
                 source=self.legistar_source(event),
             )
@@ -117,16 +121,6 @@ class CookWaterSpider(LegistarSpider):
         if "hearing" in name.lower():
             return FORUM
         return BOARD
-
-    def _parse_location(self, item):
-        """
-        Parse or generate location. Url, latitutde and longitude are all
-        optional and may be more trouble than they're worth to collect.
-        """
-        return {
-            "name": item.get("Meeting Location", None),
-            "address": self.address,
-        }
 
     def _parse_title(self, item):
         """Parse or generate meeting title."""

--- a/tests/files/cook_water.json
+++ b/tests/files/cook_water.json
@@ -4,2787 +4,543 @@
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "12/20/2018",
+    "Meeting Date": "12/17/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570944&GUID=DF1E81E4-2660-42AF-A398-8296420B9341"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345735&GUID=1C69C722-92F3-4518-9C23-6CD490AE23E0"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570944&GUID=DF1E81E4-2660-42AF-A398-8296420B9341&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
+    "Accessible Minutes": "Not\u00a0available",
     "Video": "Not\u00a0available",
-    "1": null,
-    "0": null
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "12/6/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570943&GUID=A1D5BE08-E76C-4487-BB14-F3EA93BC0DA9"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570943&GUID=A1D5BE08-E76C-4487-BB14-F3EA93BC0DA9&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
-  },
-  {
-    "Name": {
-      "label": "Public Hearing",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3726&GUID=207B8554-2A71-4358-ACEC-50B0BE210B5C"
-    },
-    "Meeting Date": "12/6/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=598046&GUID=E954D941-4987-406E-8240-830C816C2108"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON BUDGET AND EMPLOYMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=598046&GUID=E954D941-4987-406E-8240-830C816C2108&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Annual Meeting",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4607&GUID=10D8F757-F0AE-4714-9965-4145BE584A51"
     },
-    "Meeting Date": "12/4/2018",
+    "Meeting Date": "12/8/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570949&GUID=529E1BE6-F6AD-4DA6-AF8A-B496816BAD49"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345797&GUID=62B8FE7D-559C-4E0D-B469-BF8A358CB20B"
     },
-    "Meeting Time": "2:00 PM",
+    "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570949&GUID=529E1BE6-F6AD-4DA6-AF8A-B496816BAD49&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "11/15/2018",
+    "Meeting Date": "12/3/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570942&GUID=B198279D-F5DD-48D8-BD44-4A01AAF0C3F0"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345734&GUID=0AA165F5-B3B0-449A-B5AC-E9AC1F85F751"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570942&GUID=B198279D-F5DD-48D8-BD44-4A01AAF0C3F0&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
-      "label": "Special Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4608&GUID=49AF7EB5-DDC6-452C-AD15-F66178EEFF34"
+      "label": "Board of Commissioners",
+      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "11/2/2018",
+    "Meeting Date": "11/19/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=598045&GUID=5007ECBA-8560-41C4-93BF-7D8B3311F35B"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345733&GUID=F1D1D129-0483-412A-99C6-5CFC339B3EF0"
     },
-    "Meeting Time": "9:00 AM",
-    "Meeting Location": "Board Room\n--em--DEPARTMENTAL BUDGET PRESENTATIONS--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=598045&GUID=5007ECBA-8560-41C4-93BF-7D8B3311F35B&Options=info&Search="
-    },
+    "Meeting Time": "10:30 AM",
+    "Meeting Location": "Board Room",
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "11/1/2018",
+    "Meeting Date": "11/5/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570941&GUID=BA4388F1-0A74-43A4-8838-A83D9B1C47B2"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345732&GUID=BA133895-AC1E-49F7-B8AB-61CAA48E9891"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570941&GUID=BA4388F1-0A74-43A4-8838-A83D9B1C47B2&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
-      "label": "Special Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4608&GUID=49AF7EB5-DDC6-452C-AD15-F66178EEFF34"
+      "label": "Board of Commissioners",
+      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "11/1/2018",
+    "Meeting Date": "10/15/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=598044&GUID=3AFDA33F-B3D3-4FE5-9B19-4B0D3214DB2F"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345731&GUID=AAC90420-76C9-42FF-881A-645C2B88C7FE"
     },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--DEPARTMENTAL BUDGET PRESENTATION--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=598044&GUID=3AFDA33F-B3D3-4FE5-9B19-4B0D3214DB2F&Options=info&Search="
-    },
+    "Meeting Time": "10:30 AM",
+    "Meeting Location": "Board Room",
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "10/18/2018",
+    "Meeting Date": "10/1/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570940&GUID=E7AB1A72-BA83-4454-9FD9-66D4B6767CC0"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345730&GUID=59ED0F85-DF54-4525-BD3D-FAF2E17E81D2"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570940&GUID=E7AB1A72-BA83-4454-9FD9-66D4B6767CC0&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "10/4/2018",
+    "Meeting Date": "9/17/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570939&GUID=41BCD992-37FF-4A64-8B95-22FDF9120177"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345729&GUID=D1E81F23-0D42-4A5D-8ABF-9D77D481ECBF"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570939&GUID=41BCD992-37FF-4A64-8B95-22FDF9120177&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "9/20/2018",
+    "Meeting Date": "9/3/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570938&GUID=43BC75FF-D0BE-421C-B5F5-DBEC8B969B91"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345728&GUID=F22669F8-8ACC-47EC-A504-11BD18211F41"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570938&GUID=43BC75FF-D0BE-421C-B5F5-DBEC8B969B91&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "9/6/2018",
+    "Meeting Date": "8/13/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570937&GUID=38C8FA7E-DAF2-46E5-84A0-EDADD7578F24"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345727&GUID=14917FCD-2C1E-4FEA-8DE8-5D856688A5D0"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570937&GUID=38C8FA7E-DAF2-46E5-84A0-EDADD7578F24&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "8/2/2018",
+    "Meeting Date": "7/16/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570936&GUID=83724FE9-94B3-4985-BF26-1060564A039A"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345726&GUID=EC92D7A1-4CE0-4F7E-8E4B-F57F380416A5"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570936&GUID=83724FE9-94B3-4985-BF26-1060564A039A&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "7/12/2018",
+    "Meeting Date": "6/18/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570935&GUID=7A82E46C-2852-4FD0-90F3-204ADB179EB4"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345725&GUID=18FD0B1A-78EA-4346-8EA6-CCA4BB1BA5C7"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570935&GUID=7A82E46C-2852-4FD0-90F3-204ADB179EB4&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "6/21/2018",
+    "Meeting Date": "6/4/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570934&GUID=8C31E11C-A203-43F6-9D2F-FB8F856396C1"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345724&GUID=4E469591-E097-4C5D-BC13-F7BD363A6872"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570934&GUID=8C31E11C-A203-43F6-9D2F-FB8F856396C1&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
+      "label": "Board of Commissioners",
+      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "6/21/2018",
+    "Meeting Date": "5/21/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=598054&GUID=28578289-4F88-4795-9FA1-165F4154C516"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345723&GUID=D0A4DE2C-4747-4176-8BFC-9E9EC5B3566A"
     },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON BUDGET AND EMPLOYMENT\r\nCapital Improvement Program--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=598054&GUID=28578289-4F88-4795-9FA1-165F4154C516&Options=info&Search="
-    },
+    "Meeting Time": "10:30 AM",
+    "Meeting Location": "Board Room",
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
+      "label": "Board of Commissioners",
+      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "6/14/2018",
+    "Meeting Date": "5/7/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=605406&GUID=1777D47D-2632-4DB7-9227-7933120D8984"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345722&GUID=5B1319E0-265A-4BCF-93B0-CBA31D50C2EE"
     },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON AFFIRMATIVE ACTION--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=605406&GUID=1777D47D-2632-4DB7-9227-7933120D8984&Options=info&Search="
-    },
+    "Meeting Time": "10:30 AM",
+    "Meeting Location": "Board Room",
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "6/7/2018",
+    "Meeting Date": "4/16/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570933&GUID=16236869-185B-4E76-B84B-A022D561B9FD"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345721&GUID=F6CEB0CF-6E96-4554-BCC5-0299B6402E0B"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570933&GUID=16236869-185B-4E76-B84B-A022D561B9FD&Options=info&Search="
-    },
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
+      "label": "Board of Commissioners",
+      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "6/7/2018",
+    "Meeting Date": "4/2/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=598034&GUID=38C1ECAA-3D43-4566-9D4E-36DDE5714C5F"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345717&GUID=2FD43FB1-33CB-4E3D-8CBA-29A2DABADDA1"
     },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON BUDGET AND EMPLOYMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=598034&GUID=38C1ECAA-3D43-4566-9D4E-36DDE5714C5F&Options=info&Search="
-    },
+    "Meeting Time": "10:30 AM",
+    "Meeting Location": "Board Room",
+    "Meeting Details": "Meeting\u00a0details",
     "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "5/17/2018",
+    "Meeting Date": "3/19/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=607284&GUID=9EB35619-E544-410D-88FB-520B723944DC"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345716&GUID=1FB4F0E3-19CC-47D6-9340-4BE729743716"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=607284&GUID=9EB35619-E544-410D-88FB-520B723944DC&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=607284&GUID=9EB35619-E544-410D-88FB-520B723944DC"
-    },
+    "Meeting Details": "Meeting\u00a0details",
+    "Agenda": "Not\u00a0available",
+    "Accessible Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=510&Mode2=Video"
-    }
+    "Accessible Minutes": "Not\u00a0available",
+    "Video": "Not\u00a0available",
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
+      "label": "Board of Commissioners",
+      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "5/17/2018",
+    "Meeting Date": "3/5/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=607691&GUID=9CF9802B-D1F8-4598-A457-C75850FA304C"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345715&GUID=1C19F3DC-D8EB-46BD-8CD9-39EB4213BD0E"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
     "Meeting Details": {
       "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=607691&GUID=9CF9802B-D1F8-4598-A457-C75850FA304C&Options=info&Search="
+      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=1345715&GUID=1C19F3DC-D8EB-46BD-8CD9-39EB4213BD0E&Options=info|&Search="
     },
-    "Agenda": "Not\u00a0available",
+    "Agenda": {
+      "label": "Agenda",
+      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=1345715&GUID=1C19F3DC-D8EB-46BD-8CD9-39EB4213BD0E"
+    },
+    "Accessible Agenda": {
+      "label": "Accessible Agenda",
+      "url": "https://mwrd.legistar.com/View.ashx?M=AADA&ID=1345715&GUID=1C19F3DC-D8EB-46BD-8CD9-39EB4213BD0E"
+    },
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "5/3/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=605739&GUID=FE2154C1-7860-431C-9C18-DDED7B5BFAE4"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=605739&GUID=FE2154C1-7860-431C-9C18-DDED7B5BFAE4&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=605739&GUID=FE2154C1-7860-431C-9C18-DDED7B5BFAE4"
-    },
+    "Accessible Minutes": "Not\u00a0available",
     "Video": {
       "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=507&Mode2=Video"
-    }
+      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=1165&Mode2=Video"
+    },
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "5/3/2018",
+    "Meeting Date": "2/19/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=605681&GUID=E80783B3-F0C5-4B50-9833-7F95DCAD63D9"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
     "Meeting Details": {
       "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=605681&GUID=E80783B3-F0C5-4B50-9833-7F95DCAD63D9&Options=info&Search="
+      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40&Options=info|&Search="
     },
     "Agenda": {
       "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=605681&GUID=E80783B3-F0C5-4B50-9833-7F95DCAD63D9"
+      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40"
     },
+    "Accessible Agenda": {
+      "label": "Accessible Agenda",
+      "url": "https://mwrd.legistar.com/View.ashx?M=AADA&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40"
+    },
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": {
       "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=605681&GUID=E80783B3-F0C5-4B50-9833-7F95DCAD63D9"
+      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40"
+    },
+    "Accessible Minutes": {
+      "label": "Accessible Minutes",
+      "url": "https://mwrd.legistar.com/View.ashx?M=MADA&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40"
     },
     "Video": {
       "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=506&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
+      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=1161&Mode2=Video"
     },
-    "Meeting Date": "5/3/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=605306&GUID=83E240D2-AC5F-4E89-99C3-3BF1C75103CE"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON ETHICS--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=605306&GUID=83E240D2-AC5F-4E89-99C3-3BF1C75103CE&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=605306&GUID=83E240D2-AC5F-4E89-99C3-3BF1C75103CE"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=605306&GUID=83E240D2-AC5F-4E89-99C3-3BF1C75103CE"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=508&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "4/19/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=602919&GUID=55CAA76C-AA2A-4666-AFE1-962F5D7F8F48"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=602919&GUID=55CAA76C-AA2A-4666-AFE1-962F5D7F8F48&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=602919&GUID=55CAA76C-AA2A-4666-AFE1-962F5D7F8F48"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=504&Mode2=Video"
-    }
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "4/19/2018",
+    "Meeting Date": "2/5/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=602881&GUID=B4896D4A-4AF9-44C7-9123-1E5D6727CAF0"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345713&GUID=58C9D04F-FC90-433E-886E-8526F06B49F4"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
     "Meeting Details": {
       "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=602881&GUID=B4896D4A-4AF9-44C7-9123-1E5D6727CAF0&Options=info&Search="
+      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=1345713&GUID=58C9D04F-FC90-433E-886E-8526F06B49F4&Options=info|&Search="
     },
     "Agenda": {
       "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=602881&GUID=B4896D4A-4AF9-44C7-9123-1E5D6727CAF0"
+      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=1345713&GUID=58C9D04F-FC90-433E-886E-8526F06B49F4"
     },
+    "Accessible Agenda": {
+      "label": "Accessible Agenda",
+      "url": "https://mwrd.legistar.com/View.ashx?M=AADA&ID=1345713&GUID=58C9D04F-FC90-433E-886E-8526F06B49F4"
+    },
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": {
       "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=602881&GUID=B4896D4A-4AF9-44C7-9123-1E5D6727CAF0"
+      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=1345713&GUID=58C9D04F-FC90-433E-886E-8526F06B49F4"
+    },
+    "Accessible Minutes": {
+      "label": "Accessible Minutes",
+      "url": "https://mwrd.legistar.com/View.ashx?M=MADA&ID=1345713&GUID=58C9D04F-FC90-433E-886E-8526F06B49F4"
     },
     "Video": {
       "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=503&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
+      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=1159&Mode2=Video"
     },
-    "Meeting Date": "4/5/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=601189&GUID=3490309B-9CB3-4786-8EA0-8CDD199D4626"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=601189&GUID=3490309B-9CB3-4786-8EA0-8CDD199D4626&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=601189&GUID=3490309B-9CB3-4786-8EA0-8CDD199D4626"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=499&Mode2=Video"
-    }
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "4/5/2018",
+    "Meeting Date": "1/22/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=600946&GUID=67079439-937D-450A-AA18-339F3A6C3555"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1379640&GUID=C4B0D0B8-E037-416A-B47C-CE078C32A394"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
     "Meeting Details": {
       "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=600946&GUID=67079439-937D-450A-AA18-339F3A6C3555&Options=info&Search="
+      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=1379640&GUID=C4B0D0B8-E037-416A-B47C-CE078C32A394&Options=info|&Search="
     },
     "Agenda": {
       "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=600946&GUID=67079439-937D-450A-AA18-339F3A6C3555"
+      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=1379640&GUID=C4B0D0B8-E037-416A-B47C-CE078C32A394"
     },
+    "Accessible Agenda": {
+      "label": "Accessible Agenda",
+      "url": "https://mwrd.legistar.com/View.ashx?M=AADA&ID=1379640&GUID=C4B0D0B8-E037-416A-B47C-CE078C32A394"
+    },
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": {
       "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=600946&GUID=67079439-937D-450A-AA18-339F3A6C3555"
+      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=1379640&GUID=C4B0D0B8-E037-416A-B47C-CE078C32A394"
+    },
+    "Accessible Minutes": {
+      "label": "Accessible Minutes",
+      "url": "https://mwrd.legistar.com/View.ashx?M=MADA&ID=1379640&GUID=C4B0D0B8-E037-416A-B47C-CE078C32A394"
     },
     "Video": {
       "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=498&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
+      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=1155&Mode2=Video"
     },
-    "Meeting Date": "4/5/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=600388&GUID=ED23D4D9-CAA0-47D5-8CDB-6206AE134812"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON ENGINEERING--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=600388&GUID=ED23D4D9-CAA0-47D5-8CDB-6206AE134812&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=600388&GUID=ED23D4D9-CAA0-47D5-8CDB-6206AE134812"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=600388&GUID=ED23D4D9-CAA0-47D5-8CDB-6206AE134812"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=500&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "3/15/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=598367&GUID=F54E132D-0095-44CF-8328-3B7D3620E7DB"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=598367&GUID=F54E132D-0095-44CF-8328-3B7D3620E7DB&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=598367&GUID=F54E132D-0095-44CF-8328-3B7D3620E7DB"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=495&Mode2=Video"
-    }
+    "eComment": "Not\u00a0available"
   },
   {
     "Name": {
       "label": "Board of Commissioners",
       "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
     },
-    "Meeting Date": "3/15/2018",
+    "Meeting Date": "1/8/2026",
     "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=598366&GUID=1CE70888-6BCA-42C4-BD27-4E01B1385531"
+      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=1345711&GUID=76C3C5F6-01B3-43FA-A5B0-370C748FB42F"
     },
     "Meeting Time": "10:30 AM",
     "Meeting Location": "Board Room",
     "Meeting Details": {
       "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=598366&GUID=1CE70888-6BCA-42C4-BD27-4E01B1385531&Options=info&Search="
+      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=1345711&GUID=76C3C5F6-01B3-43FA-A5B0-370C748FB42F&Options=info|&Search="
     },
     "Agenda": {
       "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=598366&GUID=1CE70888-6BCA-42C4-BD27-4E01B1385531"
+      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=1345711&GUID=76C3C5F6-01B3-43FA-A5B0-370C748FB42F"
     },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=598366&GUID=1CE70888-6BCA-42C4-BD27-4E01B1385531"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=494&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "3/1/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=596683&GUID=AC4CC56D-CDC6-40CD-A52F-8B02051EA269"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=596683&GUID=AC4CC56D-CDC6-40CD-A52F-8B02051EA269&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=596683&GUID=AC4CC56D-CDC6-40CD-A52F-8B02051EA269"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=492&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "3/1/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=596665&GUID=A7EDFDF3-CA75-4476-A580-128675806605"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=596665&GUID=A7EDFDF3-CA75-4476-A580-128675806605&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=596665&GUID=A7EDFDF3-CA75-4476-A580-128675806605"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=596665&GUID=A7EDFDF3-CA75-4476-A580-128675806605"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=491&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "2/15/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=594451&GUID=428DA7D0-82FC-4864-921D-84831EE70104"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=594451&GUID=428DA7D0-82FC-4864-921D-84831EE70104&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=594451&GUID=428DA7D0-82FC-4864-921D-84831EE70104"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=489&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "2/15/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=594045&GUID=A94267D3-BF39-44EB-91B4-25F9092E7C5C"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=594045&GUID=A94267D3-BF39-44EB-91B4-25F9092E7C5C&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=594045&GUID=A94267D3-BF39-44EB-91B4-25F9092E7C5C"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=594045&GUID=A94267D3-BF39-44EB-91B4-25F9092E7C5C"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=488&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "2/1/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=592128&GUID=4984358B-D756-4252-B339-DE57109C64DF"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=592128&GUID=4984358B-D756-4252-B339-DE57109C64DF&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=592128&GUID=4984358B-D756-4252-B339-DE57109C64DF"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=486&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "2/1/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=591809&GUID=A460726D-EF26-49F4-A3BD-8FB1CB91232C"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=591809&GUID=A460726D-EF26-49F4-A3BD-8FB1CB91232C&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=591809&GUID=A460726D-EF26-49F4-A3BD-8FB1CB91232C"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=591809&GUID=A460726D-EF26-49F4-A3BD-8FB1CB91232C"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=485&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "1/18/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=588182&GUID=45966B1E-33CF-4D9E-B8A6-C61569BC6CA4"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=588182&GUID=45966B1E-33CF-4D9E-B8A6-C61569BC6CA4&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=588182&GUID=45966B1E-33CF-4D9E-B8A6-C61569BC6CA4"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=483&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "1/18/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=588023&GUID=20328FF7-C8B7-4A6C-9631-2F35A84B5F9E"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=588023&GUID=20328FF7-C8B7-4A6C-9631-2F35A84B5F9E&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=588023&GUID=20328FF7-C8B7-4A6C-9631-2F35A84B5F9E"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=588023&GUID=20328FF7-C8B7-4A6C-9631-2F35A84B5F9E"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=482&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "1/4/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=585489&GUID=3D9DA6C0-E5DF-435A-80FC-FC9309F16B78"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=585489&GUID=3D9DA6C0-E5DF-435A-80FC-FC9309F16B78&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=585489&GUID=3D9DA6C0-E5DF-435A-80FC-FC9309F16B78"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=480&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "1/4/2018",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=584967&GUID=6D515B3B-3113-4A88-A8E0-2A6844972D42"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=584967&GUID=6D515B3B-3113-4A88-A8E0-2A6844972D42&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=584967&GUID=6D515B3B-3113-4A88-A8E0-2A6844972D42"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=584967&GUID=6D515B3B-3113-4A88-A8E0-2A6844972D42"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=479&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "12/21/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=583164&GUID=1599B18C-F189-41D9-945E-A11328182525"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=583164&GUID=1599B18C-F189-41D9-945E-A11328182525&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=583164&GUID=1599B18C-F189-41D9-945E-A11328182525"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=477&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "12/21/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=582627&GUID=1D6E0E0C-3EF4-46FF-9714-930114F18D43"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=582627&GUID=1D6E0E0C-3EF4-46FF-9714-930114F18D43&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=582627&GUID=1D6E0E0C-3EF4-46FF-9714-930114F18D43"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=582627&GUID=1D6E0E0C-3EF4-46FF-9714-930114F18D43"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=476&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Special Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4608&GUID=49AF7EB5-DDC6-452C-AD15-F66178EEFF34"
-    },
-    "Meeting Date": "12/14/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=580644&GUID=BB1E5689-461E-40A7-8580-32B568394891"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room\n--em--TO ADOPT THE 2018 BUDGET--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=580644&GUID=BB1E5689-461E-40A7-8580-32B568394891&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=580644&GUID=BB1E5689-461E-40A7-8580-32B568394891"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=580644&GUID=BB1E5689-461E-40A7-8580-32B568394891"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=474&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Public Hearing",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3726&GUID=207B8554-2A71-4358-ACEC-50B0BE210B5C"
-    },
-    "Meeting Date": "12/7/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=544134&GUID=AF56FCCA-09F4-47B2-B18C-F837889B6C22"
-    },
-    "Meeting Time": "2:00 PM",
-    "Meeting Location": "Board Room\n--em--CONSIDER THE PROPOSED BUDGET--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=544134&GUID=AF56FCCA-09F4-47B2-B18C-F837889B6C22&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=544134&GUID=AF56FCCA-09F4-47B2-B18C-F837889B6C22"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=544134&GUID=AF56FCCA-09F4-47B2-B18C-F837889B6C22"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=470&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "12/7/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=579452&GUID=CB5F56AA-B9E7-4CA8-9CDF-8908168892E2"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=579452&GUID=CB5F56AA-B9E7-4CA8-9CDF-8908168892E2&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=579452&GUID=CB5F56AA-B9E7-4CA8-9CDF-8908168892E2"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=468&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "12/7/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=578793&GUID=1C16B3EA-1BF8-4AC0-8688-CCC88048AAB8"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=578793&GUID=1C16B3EA-1BF8-4AC0-8688-CCC88048AAB8&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=578793&GUID=1C16B3EA-1BF8-4AC0-8688-CCC88048AAB8"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=578793&GUID=1C16B3EA-1BF8-4AC0-8688-CCC88048AAB8"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=467&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Annual Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4607&GUID=10D8F757-F0AE-4714-9965-4145BE584A51"
-    },
-    "Meeting Date": "12/5/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=512099&GUID=FA766F92-3E90-432F-9CF7-EC366B7450EF"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=512099&GUID=FA766F92-3E90-432F-9CF7-EC366B7450EF&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=512099&GUID=FA766F92-3E90-432F-9CF7-EC366B7450EF"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=512099&GUID=FA766F92-3E90-432F-9CF7-EC366B7450EF"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=466&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Special Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4608&GUID=49AF7EB5-DDC6-452C-AD15-F66178EEFF34"
-    },
-    "Meeting Date": "11/20/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=575513&GUID=41A0BB6A-9833-458D-80CE-97726A664776"
-    },
-    "Meeting Time": "2:45 PM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=575513&GUID=41A0BB6A-9833-458D-80CE-97726A664776&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=575513&GUID=41A0BB6A-9833-458D-80CE-97726A664776"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=575513&GUID=41A0BB6A-9833-458D-80CE-97726A664776"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=463&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "11/16/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=574924&GUID=55F13F38-09C8-4D95-B512-46E7BB52E07C"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=574924&GUID=55F13F38-09C8-4D95-B512-46E7BB52E07C&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=574924&GUID=55F13F38-09C8-4D95-B512-46E7BB52E07C"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=461&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "11/16/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=574871&GUID=8AB7AF1F-4C5E-4283-99BD-B74843C75140"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=574871&GUID=8AB7AF1F-4C5E-4283-99BD-B74843C75140&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=574871&GUID=8AB7AF1F-4C5E-4283-99BD-B74843C75140"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=574871&GUID=8AB7AF1F-4C5E-4283-99BD-B74843C75140"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=460&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "11/15/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=574000&GUID=C5190F26-2F72-43A9-80AA-46CB419BA2C2"
-    },
-    "Meeting Time": "12:30 PM",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON ENGINEERING--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=574000&GUID=C5190F26-2F72-43A9-80AA-46CB419BA2C2&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=574000&GUID=C5190F26-2F72-43A9-80AA-46CB419BA2C2"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=574000&GUID=C5190F26-2F72-43A9-80AA-46CB419BA2C2"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=457&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Special Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4608&GUID=49AF7EB5-DDC6-452C-AD15-F66178EEFF34"
-    },
-    "Meeting Date": "11/2/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=544131&GUID=C9BC191A-9095-4EDB-AB37-93F328C396F8"
-    },
-    "Meeting Time": "1:00 PM",
-    "Meeting Location": "Board Room\n--em--DEPARTMENTAL BUDGET PRESENTATIONS--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=544131&GUID=C9BC191A-9095-4EDB-AB37-93F328C396F8&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=544131&GUID=C9BC191A-9095-4EDB-AB37-93F328C396F8"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=544131&GUID=C9BC191A-9095-4EDB-AB37-93F328C396F8"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=455&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "11/2/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=572384&GUID=0964668F-D9BA-49E9-A1B7-B0BD300D0F17"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=572384&GUID=0964668F-D9BA-49E9-A1B7-B0BD300D0F17&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=572384&GUID=0964668F-D9BA-49E9-A1B7-B0BD300D0F17"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=453&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "11/2/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=572014&GUID=0142EE4A-9EED-4CF0-8924-A3FEFD3986B9"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=572014&GUID=0142EE4A-9EED-4CF0-8924-A3FEFD3986B9&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=572014&GUID=0142EE4A-9EED-4CF0-8924-A3FEFD3986B9"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=572014&GUID=0142EE4A-9EED-4CF0-8924-A3FEFD3986B9"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=452&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "10/19/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570521&GUID=419C7C36-36F2-4D4A-AF56-76FA097AF88C"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570521&GUID=419C7C36-36F2-4D4A-AF56-76FA097AF88C&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=570521&GUID=419C7C36-36F2-4D4A-AF56-76FA097AF88C"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=450&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "10/19/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=570172&GUID=9276FE4B-9DBD-4AE7-8A72-ACB720A41679"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=570172&GUID=9276FE4B-9DBD-4AE7-8A72-ACB720A41679&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=570172&GUID=9276FE4B-9DBD-4AE7-8A72-ACB720A41679"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=570172&GUID=9276FE4B-9DBD-4AE7-8A72-ACB720A41679"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=449&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "10/5/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=568714&GUID=86687153-30DD-4187-BFA9-8EB20EE3A570"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=568714&GUID=86687153-30DD-4187-BFA9-8EB20EE3A570&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=568714&GUID=86687153-30DD-4187-BFA9-8EB20EE3A570"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=445&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "10/5/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=566452&GUID=BD6C03D5-9B71-4BEF-8BA0-BB9E4160EC7B"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=566452&GUID=BD6C03D5-9B71-4BEF-8BA0-BB9E4160EC7B&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=566452&GUID=BD6C03D5-9B71-4BEF-8BA0-BB9E4160EC7B"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=566452&GUID=BD6C03D5-9B71-4BEF-8BA0-BB9E4160EC7B"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=444&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "10/5/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=565028&GUID=0662D7AC-6CD0-448A-B71D-BD1FE5C44EFB"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON STORMWATER MANAGEMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=565028&GUID=0662D7AC-6CD0-448A-B71D-BD1FE5C44EFB&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=565028&GUID=0662D7AC-6CD0-448A-B71D-BD1FE5C44EFB"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=565028&GUID=0662D7AC-6CD0-448A-B71D-BD1FE5C44EFB"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=446&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "9/14/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=564162&GUID=C095BE51-3C69-47FE-B207-A611A2F2A3EB"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=564162&GUID=C095BE51-3C69-47FE-B207-A611A2F2A3EB&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=564162&GUID=C095BE51-3C69-47FE-B207-A611A2F2A3EB"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=442&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "9/14/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=563798&GUID=73CC5234-6708-4E65-AA66-CFD5BCD8A6FC"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=563798&GUID=73CC5234-6708-4E65-AA66-CFD5BCD8A6FC&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=563798&GUID=73CC5234-6708-4E65-AA66-CFD5BCD8A6FC"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=563798&GUID=73CC5234-6708-4E65-AA66-CFD5BCD8A6FC"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=441&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "8/31/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=562714&GUID=0FCE4376-509B-4846-BB8B-AF62AC259968"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=562714&GUID=0FCE4376-509B-4846-BB8B-AF62AC259968&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=562714&GUID=0FCE4376-509B-4846-BB8B-AF62AC259968"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=436&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "8/31/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=562492&GUID=8265A02F-C9F3-454A-96E6-D76668CC8F43"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=562492&GUID=8265A02F-C9F3-454A-96E6-D76668CC8F43&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=562492&GUID=8265A02F-C9F3-454A-96E6-D76668CC8F43"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=562492&GUID=8265A02F-C9F3-454A-96E6-D76668CC8F43"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=435&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "8/31/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=561891&GUID=39693A19-BE51-4D34-98DE-F2FE775AA003"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON ETHICS--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=561891&GUID=39693A19-BE51-4D34-98DE-F2FE775AA003&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=561891&GUID=39693A19-BE51-4D34-98DE-F2FE775AA003"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=561891&GUID=39693A19-BE51-4D34-98DE-F2FE775AA003"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=437&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "8/17/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=557562&GUID=EF6E2D53-E7FF-43F7-830F-980474A4D386"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON STORMWATER MANAGEMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=557562&GUID=EF6E2D53-E7FF-43F7-830F-980474A4D386&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=557562&GUID=EF6E2D53-E7FF-43F7-830F-980474A4D386"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=557562&GUID=EF6E2D53-E7FF-43F7-830F-980474A4D386"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=432&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "8/3/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=559306&GUID=9549E96F-817E-4EFE-A0BD-0FDE32859907"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=559306&GUID=9549E96F-817E-4EFE-A0BD-0FDE32859907&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=559306&GUID=9549E96F-817E-4EFE-A0BD-0FDE32859907"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=428&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "8/3/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=558952&GUID=87E84987-81FE-484B-8852-0A63DA137DEC"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=558952&GUID=87E84987-81FE-484B-8852-0A63DA137DEC&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=558952&GUID=87E84987-81FE-484B-8852-0A63DA137DEC"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=558952&GUID=87E84987-81FE-484B-8852-0A63DA137DEC"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=427&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "8/3/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=557561&GUID=646B12AC-D8C3-4E9F-893D-24A3680CD972"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON PROCUREMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=557561&GUID=646B12AC-D8C3-4E9F-893D-24A3680CD972&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=557561&GUID=646B12AC-D8C3-4E9F-893D-24A3680CD972"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=557561&GUID=646B12AC-D8C3-4E9F-893D-24A3680CD972"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=429&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "7/31/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=557552&GUID=CC456297-943B-479A-866C-7F9EF15B94A9"
-    },
-    "Meeting Time": "11:00 AM",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON LABOR AND INDUSTRIAL RELATIONS--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=557552&GUID=CC456297-943B-479A-866C-7F9EF15B94A9&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=557552&GUID=CC456297-943B-479A-866C-7F9EF15B94A9"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=557552&GUID=CC456297-943B-479A-866C-7F9EF15B94A9"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=424&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "7/27/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=558016&GUID=D8E1ECE8-362A-4589-92A8-4D4218FFD8A0"
-    },
-    "Meeting Time": "11:00 AM",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON LABOR AND INDUSTRIAL RELATIONS\r\nHAS BEEN RESCHEDULED TO JULY 31, 2017--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=558016&GUID=D8E1ECE8-362A-4589-92A8-4D4218FFD8A0&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": "Not\u00a0available",
-    "Video": "Not\u00a0available"
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "7/6/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=556307&GUID=234F6F94-499E-43C3-B8C1-76BC255FF2EB"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=556307&GUID=234F6F94-499E-43C3-B8C1-76BC255FF2EB&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=556307&GUID=234F6F94-499E-43C3-B8C1-76BC255FF2EB"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=422&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "7/6/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=556106&GUID=4E3571DA-CF36-43D0-A70A-641BB2985953"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=556106&GUID=4E3571DA-CF36-43D0-A70A-641BB2985953&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=556106&GUID=4E3571DA-CF36-43D0-A70A-641BB2985953"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=556106&GUID=4E3571DA-CF36-43D0-A70A-641BB2985953"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=421&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "6/15/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=553301&GUID=5FEA30D2-FC8E-4D62-BB4C-0E8231B0C176"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=553301&GUID=5FEA30D2-FC8E-4D62-BB4C-0E8231B0C176&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=553301&GUID=5FEA30D2-FC8E-4D62-BB4C-0E8231B0C176"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=416&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "6/15/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=553238&GUID=AF7DE10A-247B-4913-8C38-FC40D6C59BF3"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=553238&GUID=AF7DE10A-247B-4913-8C38-FC40D6C59BF3&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=553238&GUID=AF7DE10A-247B-4913-8C38-FC40D6C59BF3"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=553238&GUID=AF7DE10A-247B-4913-8C38-FC40D6C59BF3"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=415&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "6/15/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=547126&GUID=A63683F9-68F4-4477-BD31-1AA0CA4847C0"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON BUDGET AND EMPLOYMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=547126&GUID=A63683F9-68F4-4477-BD31-1AA0CA4847C0&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=547126&GUID=A63683F9-68F4-4477-BD31-1AA0CA4847C0"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=547126&GUID=A63683F9-68F4-4477-BD31-1AA0CA4847C0"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=419&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "6/1/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=550992&GUID=38C4F994-AA1A-4076-8D36-1AC6B0A41097"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=550992&GUID=38C4F994-AA1A-4076-8D36-1AC6B0A41097&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=550992&GUID=38C4F994-AA1A-4076-8D36-1AC6B0A41097"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=410&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "6/1/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=550823&GUID=184A4E4D-C6C2-4EB2-8682-2C09CA154831"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=550823&GUID=184A4E4D-C6C2-4EB2-8682-2C09CA154831&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=550823&GUID=184A4E4D-C6C2-4EB2-8682-2C09CA154831"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=550823&GUID=184A4E4D-C6C2-4EB2-8682-2C09CA154831"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=409&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "6/1/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=547125&GUID=1B7E98FC-4FA5-41D2-96F6-717ADBA0CA49"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON BUDGET AND EMPLOYMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=547125&GUID=1B7E98FC-4FA5-41D2-96F6-717ADBA0CA49&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=547125&GUID=1B7E98FC-4FA5-41D2-96F6-717ADBA0CA49"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=547125&GUID=1B7E98FC-4FA5-41D2-96F6-717ADBA0CA49"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=411&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "5/18/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=549558&GUID=CB19B3CD-36A2-462E-B065-DBEB428AD43B"
+    "Accessible Agenda": {
+      "label": "Accessible Agenda",
+      "url": "https://mwrd.legistar.com/View.ashx?M=AADA&ID=1345711&GUID=76C3C5F6-01B3-43FA-A5B0-370C748FB42F"
     },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=549558&GUID=CB19B3CD-36A2-462E-B065-DBEB428AD43B&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=549558&GUID=CB19B3CD-36A2-462E-B065-DBEB428AD43B"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=404&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "5/18/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=512087&GUID=5E7D5EC4-DAF3-4DF9-A603-EE9EC34FF075"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=512087&GUID=5E7D5EC4-DAF3-4DF9-A603-EE9EC34FF075&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=512087&GUID=5E7D5EC4-DAF3-4DF9-A603-EE9EC34FF075"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=512087&GUID=5E7D5EC4-DAF3-4DF9-A603-EE9EC34FF075"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=403&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "5/18/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=547124&GUID=CA01D171-843E-4055-9121-450D875EABAE"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON BUDGET AND EMPLOYMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=547124&GUID=CA01D171-843E-4055-9121-450D875EABAE&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=547124&GUID=CA01D171-843E-4055-9121-450D875EABAE"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=547124&GUID=CA01D171-843E-4055-9121-450D875EABAE"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=405&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "5/4/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=546635&GUID=A0CAB0A3-E13F-4117-85F5-01D6E9277497"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=546635&GUID=A0CAB0A3-E13F-4117-85F5-01D6E9277497&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=546635&GUID=A0CAB0A3-E13F-4117-85F5-01D6E9277497"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=401&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "5/4/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=546243&GUID=F15F8D23-1EB6-4370-94E9-DA01EFF131A2"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=546243&GUID=F15F8D23-1EB6-4370-94E9-DA01EFF131A2&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=546243&GUID=F15F8D23-1EB6-4370-94E9-DA01EFF131A2"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=546243&GUID=F15F8D23-1EB6-4370-94E9-DA01EFF131A2"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=400&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "4/20/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=544945&GUID=78AA20BC-C808-41E1-BA1F-6DEA58DA5AEF"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=544945&GUID=78AA20BC-C808-41E1-BA1F-6DEA58DA5AEF&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=544945&GUID=78AA20BC-C808-41E1-BA1F-6DEA58DA5AEF"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=398&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "4/20/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=544466&GUID=43C31807-9681-413E-8B7E-8DA6AE3B6935"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=544466&GUID=43C31807-9681-413E-8B7E-8DA6AE3B6935&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=544466&GUID=43C31807-9681-413E-8B7E-8DA6AE3B6935"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=544466&GUID=43C31807-9681-413E-8B7E-8DA6AE3B6935"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=397&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "4/6/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=543247&GUID=3E6C1BEE-66F1-4942-8445-E49030BAC40A"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=543247&GUID=3E6C1BEE-66F1-4942-8445-E49030BAC40A&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=543247&GUID=3E6C1BEE-66F1-4942-8445-E49030BAC40A"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=392&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "4/6/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=512084&GUID=0A37A4D6-B496-4D2F-B847-15F046652F75"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=512084&GUID=0A37A4D6-B496-4D2F-B847-15F046652F75&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=512084&GUID=0A37A4D6-B496-4D2F-B847-15F046652F75"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=512084&GUID=0A37A4D6-B496-4D2F-B847-15F046652F75"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=391&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "4/6/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=539852&GUID=81C8FFCF-DD2F-4960-8EA6-98210D86793F"
-    },
-    "Meeting Time": "",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON STORMWATER MANAGEMENT--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=539852&GUID=81C8FFCF-DD2F-4960-8EA6-98210D86793F&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=539852&GUID=81C8FFCF-DD2F-4960-8EA6-98210D86793F"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=539852&GUID=81C8FFCF-DD2F-4960-8EA6-98210D86793F"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=393&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "3/16/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=538572&GUID=AA9F88EA-AA3D-4D5A-8CE0-6880005926AB"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=538572&GUID=AA9F88EA-AA3D-4D5A-8CE0-6880005926AB&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=538572&GUID=AA9F88EA-AA3D-4D5A-8CE0-6880005926AB"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=388&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "3/16/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=538530&GUID=CBBBA5E5-0645-4E74-9DAD-484DDEF8DD39"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=538530&GUID=CBBBA5E5-0645-4E74-9DAD-484DDEF8DD39&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=538530&GUID=CBBBA5E5-0645-4E74-9DAD-484DDEF8DD39"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=538530&GUID=CBBBA5E5-0645-4E74-9DAD-484DDEF8DD39"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=387&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "3/2/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=536944&GUID=9D8545BC-29E5-4220-9AD3-F06A63D42E51"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=536944&GUID=9D8545BC-29E5-4220-9AD3-F06A63D42E51&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=536944&GUID=9D8545BC-29E5-4220-9AD3-F06A63D42E51"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=385&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "3/2/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=536745&GUID=F175394E-95DC-41D6-BEFC-C50F7C39152D"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=536745&GUID=F175394E-95DC-41D6-BEFC-C50F7C39152D&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=536745&GUID=F175394E-95DC-41D6-BEFC-C50F7C39152D"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=536745&GUID=F175394E-95DC-41D6-BEFC-C50F7C39152D"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=384&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Study Session",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3725&GUID=7F20BCD0-B10F-427F-90C0-4386DB8A6C6D"
-    },
-    "Meeting Date": "2/23/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=535119&GUID=2CDB30FD-CE14-4670-8952-9826E1B04112"
-    },
-    "Meeting Time": "2:00 PM",
-    "Meeting Location": "Board Room\n--em--COMMITTEE ON STATE LEGISLATION AND RULES--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=535119&GUID=2CDB30FD-CE14-4670-8952-9826E1B04112&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=535119&GUID=2CDB30FD-CE14-4670-8952-9826E1B04112"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=535119&GUID=2CDB30FD-CE14-4670-8952-9826E1B04112"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=382&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "2/16/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=534937&GUID=B137776B-9A05-4721-883A-4E3F5EAF12BE"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=534937&GUID=B137776B-9A05-4721-883A-4E3F5EAF12BE&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=534937&GUID=B137776B-9A05-4721-883A-4E3F5EAF12BE"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=380&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "2/16/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=534728&GUID=89ACF4CA-0A1D-4D32-A1B3-2C179F45405A"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=534728&GUID=89ACF4CA-0A1D-4D32-A1B3-2C179F45405A&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=534728&GUID=89ACF4CA-0A1D-4D32-A1B3-2C179F45405A"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=534728&GUID=89ACF4CA-0A1D-4D32-A1B3-2C179F45405A"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=379&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "2/2/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=531706&GUID=E1FB989F-5A37-4F42-83AC-A64FDA206E20"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=531706&GUID=E1FB989F-5A37-4F42-83AC-A64FDA206E20&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=531706&GUID=E1FB989F-5A37-4F42-83AC-A64FDA206E20"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=377&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "2/2/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=531607&GUID=008B097B-E078-4342-ADCE-0F95C4AEBDB4"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=531607&GUID=008B097B-E078-4342-ADCE-0F95C4AEBDB4&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=531607&GUID=008B097B-E078-4342-ADCE-0F95C4AEBDB4"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=531607&GUID=008B097B-E078-4342-ADCE-0F95C4AEBDB4"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=376&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "1/19/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=528920&GUID=DBEEB905-D764-4A80-9B46-DCA526A8A6F9"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=528920&GUID=DBEEB905-D764-4A80-9B46-DCA526A8A6F9&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=528920&GUID=DBEEB905-D764-4A80-9B46-DCA526A8A6F9"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=374&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "1/19/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=512079&GUID=639B6156-6A59-44C3-A2B7-F6F5735032C0"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=512079&GUID=639B6156-6A59-44C3-A2B7-F6F5735032C0&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=512079&GUID=639B6156-6A59-44C3-A2B7-F6F5735032C0"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=512079&GUID=639B6156-6A59-44C3-A2B7-F6F5735032C0"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=373&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "1/5/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=525629&GUID=17235D6E-1385-4716-88F5-A1586BC5FA94"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=525629&GUID=17235D6E-1385-4716-88F5-A1586BC5FA94&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=525629&GUID=17235D6E-1385-4716-88F5-A1586BC5FA94"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=369&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "1/5/2017",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=525342&GUID=B52764C1-2BF0-47E5-BCB3-E212D4C1EEC0"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=525342&GUID=B52764C1-2BF0-47E5-BCB3-E212D4C1EEC0&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=525342&GUID=B52764C1-2BF0-47E5-BCB3-E212D4C1EEC0"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=525342&GUID=B52764C1-2BF0-47E5-BCB3-E212D4C1EEC0"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=370&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "12/15/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=521911&GUID=5D1D60B2-3FB5-41A7-B098-2E288DC9BAED"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=521911&GUID=5D1D60B2-3FB5-41A7-B098-2E288DC9BAED&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=521911&GUID=5D1D60B2-3FB5-41A7-B098-2E288DC9BAED"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=366&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "12/15/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=437016&GUID=168CB96E-8194-4342-9FA2-1A4C3CE5102C"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=437016&GUID=168CB96E-8194-4342-9FA2-1A4C3CE5102C&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=437016&GUID=168CB96E-8194-4342-9FA2-1A4C3CE5102C"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=437016&GUID=168CB96E-8194-4342-9FA2-1A4C3CE5102C"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=365&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Special Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4608&GUID=49AF7EB5-DDC6-452C-AD15-F66178EEFF34"
-    },
-    "Meeting Date": "12/8/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=479389&GUID=C898867C-5DB7-4988-BECF-4C95CD1664BC"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room\n--em--ADOPT THE 2017 BUDGET--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=479389&GUID=C898867C-5DB7-4988-BECF-4C95CD1664BC&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=479389&GUID=C898867C-5DB7-4988-BECF-4C95CD1664BC"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=479389&GUID=C898867C-5DB7-4988-BECF-4C95CD1664BC"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=363&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Annual Meeting",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=4607&GUID=10D8F757-F0AE-4714-9965-4145BE584A51"
-    },
-    "Meeting Date": "12/6/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=437023&GUID=C9149294-4D33-411D-9C2B-9A2205747A59"
-    },
-    "Meeting Time": "2:00 PM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=437023&GUID=C9149294-4D33-411D-9C2B-9A2205747A59&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=437023&GUID=C9149294-4D33-411D-9C2B-9A2205747A59"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=437023&GUID=C9149294-4D33-411D-9C2B-9A2205747A59"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=361&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Public Hearing",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=3726&GUID=207B8554-2A71-4358-ACEC-50B0BE210B5C"
-    },
-    "Meeting Date": "12/1/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=479388&GUID=C7536125-51E1-4892-843B-D7F1F9DD56C9"
-    },
-    "Meeting Time": "2:00 PM",
-    "Meeting Location": "Board Room\n--em--CONSIDER THE PROPOSED BUDGET--em--",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=479388&GUID=C7536125-51E1-4892-843B-D7F1F9DD56C9&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=479388&GUID=C7536125-51E1-4892-843B-D7F1F9DD56C9"
-    },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=479388&GUID=C7536125-51E1-4892-843B-D7F1F9DD56C9"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=358&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "12/1/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=518666&GUID=82E7AE18-AC5D-4051-81BC-1F8DE9EC5C1C"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=518666&GUID=82E7AE18-AC5D-4051-81BC-1F8DE9EC5C1C&Options=info&Search="
-    },
-    "Agenda": "Not\u00a0available",
+    "Agenda Packet": "Not\u00a0available",
     "Minutes": {
       "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=518666&GUID=82E7AE18-AC5D-4051-81BC-1F8DE9EC5C1C"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=357&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Board of Commissioners",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"
-    },
-    "Meeting Date": "12/1/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=437015&GUID=639F6AB7-6E76-4429-B6F5-FCEB3DC609C5"
-    },
-    "Meeting Time": "10:30 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=437015&GUID=639F6AB7-6E76-4429-B6F5-FCEB3DC609C5&Options=info&Search="
-    },
-    "Agenda": {
-      "label": "Agenda",
-      "url": "https://mwrd.legistar.com/View.ashx?M=A&ID=437015&GUID=639F6AB7-6E76-4429-B6F5-FCEB3DC609C5"
+      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=1345711&GUID=76C3C5F6-01B3-43FA-A5B0-370C748FB42F"
     },
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=437015&GUID=639F6AB7-6E76-4429-B6F5-FCEB3DC609C5"
+    "Accessible Minutes": {
+      "label": "Accessible Minutes",
+      "url": "https://mwrd.legistar.com/View.ashx?M=MADA&ID=1345711&GUID=76C3C5F6-01B3-43FA-A5B0-370C748FB42F"
     },
     "Video": {
       "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=356&Mode2=Video"
-    }
-  },
-  {
-    "Name": {
-      "label": "Committee of the Whole",
-      "url": "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1657&GUID=485834CC-857E-445D-B688-34382E0671C0"
-    },
-    "Meeting Date": "11/17/2016",
-    "iCalendar": {
-      "url": "https://mwrd.legistar.com/View.ashx?M=IC&ID=516170&GUID=9A3D7747-3935-43C0-831D-3906804477E4"
-    },
-    "Meeting Time": "10:35 AM",
-    "Meeting Location": "Board Room",
-    "Meeting Details": {
-      "label": "Meeting\u00a0details",
-      "url": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=516170&GUID=9A3D7747-3935-43C0-831D-3906804477E4&Options=info&Search="
+      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=1153&Mode2=Video"
     },
-    "Agenda": "Not\u00a0available",
-    "Minutes": {
-      "label": "Minutes",
-      "url": "https://mwrd.legistar.com/View.ashx?M=M&ID=516170&GUID=9A3D7747-3935-43C0-831D-3906804477E4"
-    },
-    "Video": {
-      "label": "Video",
-      "url": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=353&Mode2=Video"
-    }
+    "eComment": "Not\u00a0available"
   }
 ]

--- a/tests/test_cook_water.py
+++ b/tests/test_cook_water.py
@@ -44,7 +44,7 @@ def test_id():
 
 
 def test_status():
-    assert parsed_items[19]["status"] == TENTATIVE
+    assert parsed_items[19]["status"] == PASSED
 
 
 def test_classification():
@@ -99,8 +99,8 @@ def test_title_not_study_session(item):
     assert item["title"] != "Study Session"
 
 
-def test_status():
-    assert parsed_items[-1]["status"] == PASSED
+def test_tentative_status():
+    assert parsed_items[0]["status"] == TENTATIVE
 
 
 @pytest.mark.parametrize("item", parsed_items)

--- a/tests/test_cook_water.py
+++ b/tests/test_cook_water.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from os.path import dirname, join
 
 import pytest
-from city_scrapers_core.constants import BOARD, PASSED
+from city_scrapers_core.constants import BOARD, PASSED, TENTATIVE
 from freezegun import freeze_time
 from scrapy.settings import Settings
 
 from city_scrapers.spiders.cook_water import CookWaterSpider
 
-freezer = freeze_time("2018-01-01")
+freezer = freeze_time("2026-03-01")
 freezer.start()
 
 with open(join(dirname(__file__), "files", "cook_water.json"), "r") as f:
@@ -23,28 +23,36 @@ parsed_items = [item for item in spider.parse_legistar(test_response)]
 freezer.stop()
 
 
+def test_count():
+    assert len(parsed_items) == 23
+
+
 def test_title():
-    assert parsed_items[0]["title"] == "Board of Commissioners"
+    assert parsed_items[19]["title"] == "Board of Commissioners"
 
 
 def test_start():
-    assert parsed_items[0]["start"] == datetime(2018, 12, 20, 10, 30)
+    assert parsed_items[19]["start"] == datetime(2026, 2, 19, 10, 30)
 
 
 def test_end():
-    assert parsed_items[0]["end"] is None
+    assert parsed_items[19]["end"] is None
 
 
 def test_id():
-    assert parsed_items[0]["id"] == "cook_water/201812201030/x/board_of_commissioners"
+    assert parsed_items[19]["id"] == "cook_water/202602191030/x/board_of_commissioners"
+
+
+def test_status():
+    assert parsed_items[19]["status"] == TENTATIVE
 
 
 def test_classification():
-    assert parsed_items[0]["classification"] == BOARD
+    assert parsed_items[19]["classification"] == BOARD
 
 
 def test_location():
-    assert parsed_items[0]["location"] == {
+    assert parsed_items[19]["location"] == {
         "address": "100 East Erie Street Chicago, IL 60611",
         "name": "Board Room",
     }
@@ -52,21 +60,36 @@ def test_location():
 
 def test_source():
     assert (
-        parsed_items[0]["source"]
+        parsed_items[19]["source"]
         == "https://mwrd.legistar.com/DepartmentDetail.aspx?ID=1622&GUID=5E16B4CD-0692-4016-959D-3F080D6CFFB4"  # noqa
     )
 
 
 def test_links():
-    assert parsed_items[0]["links"] == []
-    assert parsed_items[-2]["links"] == [
+    assert parsed_items[19]["links"] == [
         {
-            "href": "https://mwrd.legistar.com/View.ashx?M=M&ID=568714&GUID=86687153-30DD-4187-BFA9-8EB20EE3A570",  # noqa
+            "href": "https://mwrd.legistar.com/View.ashx?M=A&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40",  # noqa
+            "title": "Agenda",
+        },
+        {
+            "href": "https://mwrd.legistar.com/View.ashx?M=M&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40",  # noqa
             "title": "Minutes",
         },
         {
-            "href": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=445&Mode2=Video",  # noqa
+            "href": "https://mwrd.legistar.com/Video.aspx?Mode=Granicus&ID1=1161&Mode2=Video",  # noqa
             "title": "Video",
+        },
+        {
+            "href": "https://mwrd.legistar.com/MeetingDetail.aspx?ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40&Options=info|&Search=",  # noqa
+            "title": "Meeting Details",
+        },
+        {
+            "href": "https://mwrd.legistar.com/View.ashx?M=AADA&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40",  # noqa
+            "title": "Accessible Agenda",
+        },
+        {
+            "href": "https://mwrd.legistar.com/View.ashx?M=MADA&ID=1345714&GUID=4772CE57-A2D1-46EB-BDB5-AB39CFF45A40",  # noqa
+            "title": "Accessible Minutes",
         },
     ]
 


### PR DESCRIPTION
## What’s this PR do?
<!-- eg. This PR updates the scraper for Cleveland City Council because of changes to how they display their meeting schedule. -->
This PR fixes the `cook_water` spider, which scrapes meeting data from the Legistar calendar. The spider stopped working due to changes in the Legistar web page structure.

## Why are we doing this?
<!-- eg. The website’s layout was recently updated, causing our existing scraper to fail. This change ensures our scraper remains functional and continues to provide timely updates on council meetings. -->
Scraper requested from [spreadsheet](https://airtable.com/appawQXzMQREfmVEW/tblV2uXZZOeQSqjXx/viwiCr3krf5HzWpFZ?blocks=hide).

## Steps to manually test
1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Activate the virtual env and enter the pipenv shell:
```
pipenv shell
```
3. Run the spider:
```
scrapy crawl fortx_Fort_Worth_Public_Meetings -O test_output.csv
```
4. Monitor the output and ensure no errors are raised.
5. Inspect `test_output.csv` to ensure the data looks valid.
6. Ensure all tests pass
```
pytest
```

## Are there any smells or added technical debt to note?
There’s no significant technical debt.
This spider included from the previous spider "CITY_SCRAPERS_ARCHIVE"
Normal mode — skips any meeting older than 90 days, keeping the scraper fast and focused on recent/upcoming meetings.
New stuff: added `self.since_year = 2020`
Archive mode — when you run the spider with CITY_SCRAPERS_ARCHIVE=True ( ex `scrapy crawl cook_water -s CITY_SCRAPERS_ARCHIVE=True -o output.json` ), the condition is bypassed and it scrapes everything including old meetings. This is typically used for a one-time historical backfill.