### PR TITLE
🏗️ Build spider: Chicago Residential Investment Fund (RIF)

### DIFF
--- a/city_scrapers/spiders/chi_residential_investment_fund.py
+++ b/city_scrapers/spiders/chi_residential_investment_fund.py
@@ -10,7 +10,7 @@ class ChiResidentialInvestmentFundSpider(CityScrapersSpider):
     name = "chi_residential_investment_fund"
     agency = "Chicago Residential Investment Fund (RIF)"
     timezone = "America/Chicago"
-    start_urls = ["https://www.chicagorif.com/about"]
+    start_urls = ["https://www.chicagorif.com/copy-of-about"]
 
     _location = {
         "name": "City Hall, Rm. 1003A",

--- a/city_scrapers/spiders/chi_residential_investment_fund.py
+++ b/city_scrapers/spiders/chi_residential_investment_fund.py
@@ -1,0 +1,109 @@
+import re
+from datetime import datetime
+
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.items import Meeting
+from city_scrapers_core.spiders import CityScrapersSpider
+
+
+class ChiResidentialInvestmentFundSpider(CityScrapersSpider):
+    name = "chi_residential_investment_fund"
+    agency = "Chicago Residential Investment Fund (RIF)"
+    timezone = "America/Chicago"
+    start_urls = ["https://www.chicagorif.com/about"]
+
+    _location = {
+        "name": "City Hall, Rm. 1003A",
+        "address": "121 N LaSalle St, Room 1003A, Chicago, IL 60610",
+    }
+
+    def parse(self, response):
+        for item in self._parse_items(response):
+            meeting = Meeting(
+                title="Board Meeting",
+                description="",
+                classification=BOARD,
+                start=item["start"],
+                end=None,
+                all_day=False,
+                time_notes="",
+                location=self._location,
+                links=item["links"],
+                source=response.url,
+            )
+            meeting["status"] = self._get_status(meeting)
+            meeting["id"] = self._get_id(meeting)
+            yield meeting
+
+    def _get_board_dates_container(self, response):
+        """Return the rich text block that contains yearly board dates."""
+        selector = "div.wixui-rich-text[data-testid='richTextElement']"
+        for container in response.css(selector):
+            headings = [
+                self._clean_text(text)
+                for text in container.css("h5.wixui-rich-text__text::text").getall()
+            ]
+            if any("Board Dates" in heading for heading in headings):
+                return container
+        return None
+
+    def _parse_items(self, response):
+        """Group meeting dates with any related links from the board dates block."""
+        container = self._get_board_dates_container(response)
+        if container is None:
+            return []
+
+        items = []
+        current_item = None
+
+        for el in container.xpath("./h5 | ./p"):
+            if el.root.tag == "h5":
+                continue
+
+            text = self._clean_text(" ".join(el.css("::text").getall()))
+            if not text:
+                continue
+
+            parsed_start = self._parse_start_text(text)
+            if parsed_start is not None:
+                if current_item is not None:
+                    items.append(current_item)
+                current_item = {
+                    "start": parsed_start,
+                    "start_text": text,
+                    "links": [],
+                }
+                continue
+
+            if current_item is not None:
+                for a in el.css("a[href]"):
+                    href = a.attrib.get("href", "").strip()
+                    title = self._clean_text(" ".join(a.css("::text").getall())) or href
+                    if href:
+                        current_item["links"].append({"href": href, "title": title})
+
+        if current_item is not None:
+            items.append(current_item)
+
+        return items
+
+    def _parse_start_text(self, text):
+        """Parse meeting date text into a naive datetime object."""
+        text = self._clean_text(text)
+        text = re.sub(r"\bAprli\b", "April", text)
+
+        for fmt in ("%B %d, %Y", "%b %d, %Y"):
+            try:
+                return datetime.strptime(text, fmt).replace(hour=15)
+            except ValueError:
+                continue
+        return None
+
+    def _clean_text(self, text):
+        """Normalize text by removing invisible characters and collapsing whitespace."""
+        if not text:
+            return ""
+        text = text.replace("\u200b", "")
+        text = text.replace("\xa0", " ")
+        text = re.sub(r"\s+", " ", text)
+        return text.strip()

--- a/city_scrapers/spiders/chi_residential_investment_fund.py
+++ b/city_scrapers/spiders/chi_residential_investment_fund.py
@@ -14,7 +14,7 @@ class ChiResidentialInvestmentFundSpider(CityScrapersSpider):
 
     _location = {
         "name": "City Hall, Rm. 1003A",
-        "address": "121 N LaSalle St, Room 1003A, Chicago, IL 60610",
+        "address": "121 N LaSalle St, Chicago, IL 60610",
     }
 
     def parse(self, response):
@@ -94,7 +94,7 @@ class ChiResidentialInvestmentFundSpider(CityScrapersSpider):
 
         for fmt in ("%B %d, %Y", "%b %d, %Y"):
             try:
-                return datetime.strptime(text, fmt).replace(hour=15)
+                return datetime.strptime(text, fmt)
             except ValueError:
                 continue
         return None

--- a/tests/files/chi_residential_investment_fund.html
+++ b/tests/files/chi_residential_investment_fund.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Chicago Residential Investment Fund</title>
+  </head>
+  <body>
+    <!-- Unrelated rich text block with same class/testid -->
+    <div
+      id="comp-mgwqwfwl"
+      class="ku3DBC zQ9jDz qvSjx3 Vq6kJx comp-mgwqwfwl wixui-rich-text"
+      data-testid="richTextElement"
+    >
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        The RIF is in the process of establishing committees to assist in its
+        operations.
+      </p>
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text"
+          >Investment Committee</span
+        >
+      </p>
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text"
+          >Resident Advisory Committee</span
+        >
+      </p>
+    </div>
+
+    <!-- Actual board dates block -->
+    <div
+      id="comp-mgwr5ir5"
+      class="ku3DBC zQ9jDz qvSjx3 Vq6kJx comp-mgwr5ir5 wixui-rich-text"
+      data-testid="richTextElement"
+    >
+      <h5 class="font_5 wixui-rich-text__text" style="font-size: 24px">
+        2026 Board Dates
+      </h5>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span class="wixui-rich-text__text">​</span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text"
+          >January 13, 2026</span
+        >
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="text-decoration: underline" class="wixui-rich-text__text">
+          <a
+            href="https://www.chicagorif.com/_files/ugd/b6ef1a_c1fa809c87b649309a93a5ae8d3f25be.pdf"
+            target="_blank"
+            class="wixui-rich-text__text"
+          >
+            <span style="font-weight: normal" class="wixui-rich-text__text"
+              >Agenda</span
+            >
+          </a>
+        </span>
+        <span style="font-weight: normal" class="wixui-rich-text__text">
+          &nbsp;
+          <span
+            style="text-decoration: underline"
+            class="wixui-rich-text__text"
+          >
+            <a
+              href="https://www.chicagorif.com/_files/ugd/b6ef1a_169be7ab4a834cbeb759bf7caae37136.pdf"
+              target="_blank"
+              class="wixui-rich-text__text"
+            >
+              Minutes
+            </a>
+          </span>
+        </span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text">
+          <span class="wixui-rich-text__text"
+            ><span class="wixui-rich-text__text">​</span>​</span
+          >
+        </span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text"
+          >February 10, 2026</span
+        >
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: normal" class="wixui-rich-text__text">
+          <span
+            style="text-decoration: underline"
+            class="wixui-rich-text__text"
+          >
+            <a
+              href="https://www.chicagorif.com/_files/ugd/b6ef1a_b0b058445c05435d8eaca795210d5219.pdf"
+              target="_blank"
+              class="wixui-rich-text__text"
+            >
+              Agenda
+            </a>
+          </span>
+          &nbsp;
+        </span>
+        <span style="font-weight: bold" class="wixui-rich-text__text">
+          <span class="wixui-rich-text__text">​</span>
+        </span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text">
+          <span class="wixui-rich-text__text">​</span>
+        </span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text"
+          >March 10, 2026</span
+        >
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text">
+          <span class="wixui-rich-text__text">
+            <span
+              style="text-decoration: underline"
+              class="wixui-rich-text__text"
+            >
+              <a
+                href="https://www.chicagorif.com/_files/ugd/b6ef1a_5b5a3d2a11c44ccb9bdc2ff272dcc4a0.pdf"
+                target="_blank"
+                class="wixui-rich-text__text"
+              >
+                <span style="font-weight: normal" class="wixui-rich-text__text"
+                  >Agenda</span
+                >
+              </a>
+            </span>
+            ​
+          </span>
+        </span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text">
+          <span class="wixui-rich-text__text">​</span>
+        </span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text"
+          >Aprli 14, 2026</span
+        >
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: bold" class="wixui-rich-text__text">
+          <span class="wixui-rich-text__text">​</span>
+        </span>
+      </p>
+
+      <h5 class="font_5 wixui-rich-text__text" style="font-size: 24px">
+        2025 Board Dates
+      </h5>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span class="wixui-rich-text__text">​</span>
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="font-weight: 700" class="wixui-rich-text__text"
+          >September 30, 2025</span
+        >
+      </p>
+
+      <p class="font_8 wixui-rich-text__text" style="font-size: 18px">
+        <span style="text-decoration: underline" class="wixui-rich-text__text">
+          <a
+            href="https://www.chicagorif.com/_files/ugd/b6ef1a_0842ec279a19494ab008458429b7b21f.pdf"
+            target="_blank"
+            class="wixui-rich-text__text"
+          >
+            Agenda
+          </a>
+        </span>
+        <span style="text-decoration: underline" class="wixui-rich-text__text">
+          <a
+            href="https://www.chicagorif.com/_files/ugd/b6ef1a_fbfdd9d57cce4eb5ad2dc0d29900f225.pdf"
+            target="_blank"
+            class="wixui-rich-text__text"
+          >
+            Minutes
+          </a>
+        </span>
+      </p>
+    </div>
+  </body>
+</html>

--- a/tests/test_chi_residential_investment_fund.py
+++ b/tests/test_chi_residential_investment_fund.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+from os.path import dirname, join
+
+import pytest
+from city_scrapers_core.constants import BOARD
+from city_scrapers_core.utils import file_response
+from freezegun import freeze_time
+
+from city_scrapers.spiders.chi_residential_investment_fund import (
+    ChiResidentialInvestmentFundSpider,
+)
+
+
+@pytest.fixture
+def test_response():
+    return file_response(
+        join(dirname(__file__), "files", "chi_residential_investment_fund.html"),
+        url="https://www.chicagorif.com/about",
+    )
+
+
+@pytest.fixture
+def parsed_items(test_response):
+    spider = ChiResidentialInvestmentFundSpider()
+    with freeze_time("2026-03-11"):
+        return [item for item in spider.parse(test_response)]
+
+
+def test_count(parsed_items):
+    assert len(parsed_items) == 5
+
+
+def test_title(parsed_items):
+    assert parsed_items[0]["title"] == "Board Meeting"
+
+
+def test_description(parsed_items):
+    assert parsed_items[0]["description"] == ""
+
+
+def test_start(parsed_items):
+    assert parsed_items[0]["start"] == datetime(2026, 1, 13, 15, 0)
+
+
+def test_end(parsed_items):
+    assert parsed_items[0]["end"] is None
+
+
+def test_time_notes(parsed_items):
+    assert parsed_items[0]["time_notes"] == ""
+
+
+def test_status(parsed_items):
+    assert parsed_items[0]["status"] == "passed"
+
+
+def test_location(parsed_items):
+    assert parsed_items[0]["location"] == {
+        "name": "City Hall, Rm. 1003A",
+        "address": "121 N LaSalle St, Room 1003A, Chicago, IL 60610",
+    }
+
+
+def test_source(parsed_items):
+    assert parsed_items[0]["source"] == "https://www.chicagorif.com/about"
+
+
+def test_links(parsed_items):
+    assert parsed_items[0]["links"] == [
+        {
+            "href": "https://www.chicagorif.com/_files/ugd/"
+            "b6ef1a_c1fa809c87b649309a93a5ae8d3f25be.pdf",
+            "title": "Agenda",
+        },
+        {
+            "href": "https://www.chicagorif.com/_files/ugd/"
+            "b6ef1a_169be7ab4a834cbeb759bf7caae37136.pdf",
+            "title": "Minutes",
+        },
+    ]
+
+
+def test_id(parsed_items):
+    assert (
+        parsed_items[0]["id"]
+        == "chi_residential_investment_fund/202601131500/x/board_meeting"
+    )
+
+
+def test_classification(parsed_items):
+    assert parsed_items[0]["classification"] == BOARD
+
+
+def test_all_day(parsed_items):
+    for item in parsed_items:
+        assert item["all_day"] is False
+
+
+def test_aprli_typo_is_parsed(parsed_items):
+    assert parsed_items[3]["start"] == datetime(2026, 4, 14, 15, 0)
+
+
+def test_unrelated_rich_text_block_is_ignored(parsed_items):
+    assert all(item["title"] == "Board Meeting" for item in parsed_items)

--- a/tests/test_chi_residential_investment_fund.py
+++ b/tests/test_chi_residential_investment_fund.py
@@ -39,7 +39,7 @@ def test_description(parsed_items):
 
 
 def test_start(parsed_items):
-    assert parsed_items[0]["start"] == datetime(2026, 1, 13, 15, 0)
+    assert parsed_items[0]["start"] == datetime(2026, 1, 13, 0, 0)
 
 
 def test_end(parsed_items):
@@ -57,7 +57,7 @@ def test_status(parsed_items):
 def test_location(parsed_items):
     assert parsed_items[0]["location"] == {
         "name": "City Hall, Rm. 1003A",
-        "address": "121 N LaSalle St, Room 1003A, Chicago, IL 60610",
+        "address": "121 N LaSalle St, Chicago, IL 60610",
     }
 
 
@@ -83,7 +83,7 @@ def test_links(parsed_items):
 def test_id(parsed_items):
     assert (
         parsed_items[0]["id"]
-        == "chi_residential_investment_fund/202601131500/x/board_meeting"
+        == "chi_residential_investment_fund/202601130000/x/board_meeting"
     )
 
 
@@ -97,7 +97,7 @@ def test_all_day(parsed_items):
 
 
 def test_aprli_typo_is_parsed(parsed_items):
-    assert parsed_items[3]["start"] == datetime(2026, 4, 14, 15, 0)
+    assert parsed_items[3]["start"] == datetime(2026, 4, 14, 0, 0)
 
 
 def test_unrelated_rich_text_block_is_ignored(parsed_items):


### PR DESCRIPTION

## What's this PR do?
<!-- eg. This PR updates the scraper for Cleveland City Council because of changes to how they display their meeting schedule. -->
This PR adds a new spider chi_residential_investment_fund to scrape meeting data from the Chicago Residential Investment Fund (RIF).
## Why are we doing this?
<!-- eg. The website's layout was recently updated, causing our existing scraper to fail. This change ensures our scraper remains functional and continues to provide timely updates on council meetings. -->
Requested based on the following spreadsheet: [Scraper Audit Nov 2025](https://airtable.com/appawQXzMQREfmVEW/tblV2uXZZOeQSqjXx/viwiCr3krf5HzWpFZ?blocks=hide)
## Steps to manually test
<!-- Text here is not always necessary but it is generally recommended in order to aid a reviewer.
eg.
1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Activate the virtual env and enter the pipenv shell:
```
pipenv shell
```
3. Run the spider:
```
scrapy crawl kancit_hickman_mills_pub_sc_dis -O output.json
```
4. Monitor the output and ensure no errors are raised.

5. Inspect `output.json` to ensure the data looks valid.
6. Run the tests:
```
pytest
```
-->
1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Activate the virtual env and enter the pipenv shell:
```
pipenv shell
```
3. Run the spider:
```
scrapy crawl chi_residential_investment_fund -O output.json
```
4. Monitor the output and ensure no errors are raised.

5. Inspect `output.json` to ensure the data looks valid.
6. Run the tests:
```
pytest
```
## Are there any smells or added technical debt to note?
<!-- eg. The new scraping logic includes a more complex parsing routine, which might be less efficient. Future optimization or a more robust parsing strategy may be needed if the website's layout continues to evolve. -->
This spider depends on the current Wix rich-text HTML structure of the RIF page, so selector changes on the site could break parsing. It also hardcodes the meeting time and location because those values are not available in the scraped block.