### PR TITLE
Limit refresh-staging auto-merge to 2026 PRs

### DIFF
--- a/.github/workflows/refresh-staging.yml
+++ b/.github/workflows/refresh-staging.yml
@@ -38,8 +38,8 @@ jobs:
           SKIPPED_PRS=""
           MERGED_PRS=""
 
-          PRS=$(gh pr list --state open --json number,author,isDraft \
-            --jq '[.[] | select(.author.is_bot == false and .isDraft == false)] | .[].number')
+          PRS=$(gh pr list --state open --json number,author,isDraft,createdAt \
+            --jq '[.[] | select(.author.is_bot == false and .isDraft == false and (.createdAt | startswith("2026")))] | .[].number')
 
           if [ -z "$PRS" ]; then
             echo "No open PRs to merge"


### PR DESCRIPTION
## Summary
- Follow-up to #1178: skips pre-2026 open PRs in the `merge-and-prepare` job.
- Stale PRs from prior years carry legacy code (e.g. analyzer-skill folder, removed imports) that fails the current `flake8` check and aborts the daily refresh.

## Test plan
- [ ] Merge this PR
- [ ] Trigger `Refresh Staging` via `workflow_dispatch`
- [ ] Confirm only 2026-created open PRs appear in the merge log